### PR TITLE
[TASK] Modify build to use PHP 7.0.0 final

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -51,7 +51,7 @@ ENV NGINX_DIR=/usr/local/nginx \
     OPENSSL_VERSION=1.0.1p \
     NGINX_VERSION=1.8.0 \
     PHP56_VERSION=5.6.16 \
-    PHP70_VERSION=7.0.0RC8
+    PHP70_VERSION=7.0.0
 
 # BUILD PHP, nginx and other dependancies.
 ADD openssl-version-script.patch /tmp/openssl-version-script.patch

--- a/php-nginx/build_deps.sh
+++ b/php-nginx/build_deps.sh
@@ -218,7 +218,9 @@ function build_php56 {
 
 # Build PHP
 function build_php7 {
-  curl -SL "https://downloads.php.net/~ab/php-$PHP70_VERSION.tar.gz" -o php7.tar.gz
+  curl -SL "http://php.net/get/php-$PHP70_VERSION.tar.gz/from/this/mirror" -o php7.tar.gz
+  curl -SL "http://us2.php.net/get/php-$PHP70_VERSION.tar.gz.asc/from/this/mirror" -o php7.tar.gz.asc
+  gpg --verify php7.tar.gz.asc
   mkdir -p /usr/src/php7
   tar -zxf php7.tar.gz -C /usr/src/php7 --strip-components=1
   rm php7.tar.gz
@@ -299,7 +301,8 @@ function import_gpg_keys {
 
   local PHP_GPG_KEYS=" \
       0BD78B5F97500D450838F95DFE857D9A90D90EC1 \
-      6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3"
+      6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3 \
+      1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763"
 
   gpg --keyserver pgp.mit.edu --recv-keys $PHP_GPG_KEYS
 }


### PR DESCRIPTION
This pull request modifies the build script to use the available PHP 7.0.0 final tar and verifies it.

It would be nice if you could merge and push it to the gcr registry.

I signed the CLA.