### PR TITLE
[BUGFIX] Composer install should not disable functions

### DIFF
--- a/php-nginx/composer.sh
+++ b/php-nginx/composer.sh
@@ -58,6 +58,7 @@ EOF
         ${PHP_DIR}/bin/php \
         -d suhosin.executor.include.whitelist=phar \
         -d suhosin.executor.func.blacklist=none \
+        -d disable_functions= \
         /usr/local/bin/composer \
         install \
         --no-dev \


### PR DESCRIPTION
Adds a configuration directive to ``composer.sh`` to clear the disabled functions to
allow execution of composer post-install hooks that rely on native processes.

Closes #15 