### PR TITLE
[TASK] Install git into the docker image

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cron \
     curl \
     gettext \
+    git \
     libbz2-1.0 \
     libicu52 \
     libmcrypt4 \


### PR DESCRIPTION
Composer uses zip archives, if the requesting IP doesn't exceed
the GitHub API limit. If it does (which can happen easily if AppEngine
privisions a ComputeEngine builder with the same IP over and over
again), composer falls back to the VCS protocol. To make this
possible, the VCS binaries are needed inside the image.

May need a followup to consider SVN and Mercurial which are pretty
popular as well.

Long Term Solution is to check for an environment variable which
contains a GitHub oAuth Token and use it transparently in the image.

See: https://getcomposer.org/doc/articles/troubleshooting.md#api-rate-limit-and-oauth-tokens