### PR TITLE
[BUGFIX] PHP Binaries are not on $PATH

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -52,7 +52,8 @@ ENV NGINX_DIR=/usr/local/nginx \
     OPENSSL_VERSION=1.0.1p \
     NGINX_VERSION=1.8.0 \
     PHP56_VERSION=5.6.16 \
-    PHP70_VERSION=7.0.0
+    PHP70_VERSION=7.0.0 \
+    PATH=/usr/local/php/bin:$PATH
 
 # BUILD PHP, nginx and other dependancies.
 ADD openssl-version-script.patch /tmp/openssl-version-script.patch


### PR DESCRIPTION
This patch ensures that the currently used PHP binaries
are always on the PATH variable, so subsequent commands
inside the container can run arbitrary commands as well
and don't have to care about where this image puts the
binaries.

See: https://docs.docker.com/engine/articles/dockerfile_best-practices/#env
Closes #19