### PR TITLE
adds no-ansi to prevent verbose composer output

### DIFF
--- a/php-nginx/composer.sh
+++ b/php-nginx/composer.sh
@@ -81,5 +81,7 @@ EOF
         --no-dev \
         --prefer-dist \
         --optimize-autoloader \
-        --no-interaction
+        --no-interaction \
+        --no-ansi \
+        --no-progress
 fi


### PR DESCRIPTION
The following verbose composer output goes on for quite a while. The `--no-ansi` flag prevents this.

![screen shot 2016-01-06 at 12 36 41 pm](https://cloud.githubusercontent.com/assets/103941/12154060/2e486b42-b472-11e5-82c3-2a5f74711ffa.png)
