### PR TITLE
Changed the log file names so that our fluentd picks them.

### DIFF
--- a/php-nginx/php-fpm.conf
+++ b/php-nginx/php-fpm.conf
@@ -44,7 +44,7 @@ pid = /var/run/php-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /usr/local/php/var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/app_engine/php-fpm.log
+error_log = /var/log/app_engine/app-php-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -388,7 +388,7 @@ pm.max_spare_servers = 3
 
 ; The access log file
 ; Default: not set
-access.log = /var/log/app_engine/$pool.access.log
+access.log = /var/log/app_engine/php-fpm-$pool.access.log
 
 ; The access log format.
 ; The following syntax is allowed
@@ -493,7 +493,7 @@ chdir = /app
 ; Note: on highloaded environement, this can cause some delay in the page
 ; process time (several ms).
 ; Default Value: no
-;catch_workers_output = yes
+catch_workers_output = yes
 
 ; Clear environment in FPM workers
 ; Prevents arbitrary environment variables from reaching FPM worker processes

--- a/php-nginx/php.ini
+++ b/php-nginx/php.ini
@@ -586,7 +586,7 @@ html_errors = Off
 ; Example:
 ;error_log = php_errors.log
 ; Log errors to syslog (Event Log on Windows).
-error_log = /var/log/app_engine/php-error.log
+error_log = /var/log/app_engine/app-php-error.log
 
 ;windows.show_crt_warning
 ; Default value: 0


### PR DESCRIPTION
Also let php-fpm catches the stdout and stderr and stop picking up
php-fpm's access log.

Background: [The current fluentd configuration](https://github.com/GoogleCloudPlatform/appengine-sidecars-docker/blob/master/fluentd_logger/managed_vms.conf) only picks up certain file name patterns. We need to adapt our log file names to their pattern.