### PR TITLE
Added grpc extension.

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -17,12 +17,14 @@
 FROM gcr.io/google_appengine/base
 
 # persistent / runtime deps
+RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cron \
     curl \
     gettext \
     git \
     libbz2-1.0 \
+    libgrpc0 \
     libicu52 \
     libmcrypt4 \
     libmemcached11 \

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -217,6 +217,7 @@ php.ini):
 These extensions are only available with PHP 5.6:
 
 - suhosin (shared, but enabled by default)
+- gRPC (shared, grpc-0.6.0 is still beta)
 
 ## Add something to php.ini
 

--- a/php-nginx/build-scripts/apt_build_deps.sh
+++ b/php-nginx/build-scripts/apt_build_deps.sh
@@ -40,6 +40,7 @@ BUILD_DEPS=" \
     libbz2-dev \
     libcurl4-openssl-dev \
     libgettextpo-dev \
+    libgrpc-dev \
     libicu-dev \
     libmcrypt-dev \
     libmemcached-dev \

--- a/php-nginx/build-scripts/build_php56.sh
+++ b/php-nginx/build-scripts/build_php56.sh
@@ -122,6 +122,7 @@ mkdir -p ${PHP56_DIR}/lib/conf.d
 ${PHP56_DIR}/bin/pecl install memcache
 ${PHP56_DIR}/bin/pecl install mongodb
 ${PHP56_DIR}/bin/pecl install redis
+${PHP56_DIR}/bin/pecl install grpc-0.6.0
 
 rm -rf /tmp/pear
 

--- a/testapps/php56_custom/php.ini
+++ b/testapps/php56_custom/php.ini
@@ -32,3 +32,4 @@ extension=xmlrpc.so
 extension=xsl.so
 extension=mongodb.so
 extension=redis.so
+extension=grpc.so

--- a/tests/PHP5ExtensionsTest.php
+++ b/tests/PHP5ExtensionsTest.php
@@ -54,6 +54,7 @@ class PHP5ExtensionsTest extends \PHPUnit_Framework_TestCase
                 'mysql',
                 # Only available for PHP < 7 right now.
                 'suhosin',
+                'grpc',
             )
         );
         $resp = $this->client->get('extensions.php');


### PR DESCRIPTION
We need to use 0.6.0 for now. Also it's not available for PHP 7.0.