### PR TITLE
Install composer dev-dependencies on build

### DIFF
--- a/php-nginx/composer.sh
+++ b/php-nginx/composer.sh
@@ -80,7 +80,6 @@ EOF
         -d max_input_time=-1 \
         /usr/local/bin/composer \
         install \
-        --no-dev \
         --prefer-dist \
         --optimize-autoloader \
         --no-interaction \


### PR DESCRIPTION
To be able to use environment configuration in composer scripts
like for example Symfony 2 does, it is necessary to either defer
the execution of composer scripts up to a point where the developer
can set custom runtime configuration (through ENV in the Dockerfile),
which would harm the onboarding-experience as a custom Dockerfile is
necessary at all times to execute scripts, or install dev-depenencies
as well in the first place, to have them available when composer
scripts need them, because they don't know which environment they
run in.

This change applies the latter: Optimizing for production by removing
the dev-dependencies is now up to the inheriting image.

Dockerfile:
```
FROM gcr.io/php-mvm-a/php-nginx:latest

ENV SYMFONY_ENV prod

RUN cd $APP_DIR && $PHP_DIR/bin/php \
    -d suhosin.executor.include.whitelist=phar \
    -d suhosin.executor.func.blacklist=none \
    -d disable_functions= \
    -d memory_limit=-1 \
    -d max_input_time=-1 \
    /usr/local/bin/composer \
    install \
    --prefer-dist \
    --no-dev \
    --optimize-autoloader \
    --no-interaction \
    --no-ansi \
    --no-progress
```

This is necessary, because environment variables defined in the inheriting Dockerfile or app.yaml are not exposed to the container while it's being build.