### PR TITLE
Prevent composer from running any scripts on install

### DIFF
--- a/php-nginx/composer.sh
+++ b/php-nginx/composer.sh
@@ -80,6 +80,7 @@ EOF
         -d max_input_time=-1 \
         /usr/local/bin/composer \
         install \
+        --no-scripts \
         --no-dev \
         --prefer-dist \
         --optimize-autoloader \


### PR DESCRIPTION
All users that rely on composer scripts will need to extend
the Dockerfile and run the scripts manually in a second
build-step in their Dockerfile step.