### PR TITLE
Use TCP for php-fpm and increase the number of workers.

### DIFF
--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -243,6 +243,10 @@ deployment (`app.yaml` or `Dockerfile` are both fine).
 As this is your personal credential for GitHub, please make sure you do not
 commit this token to your repository.
 
+## Reserved TCP port
+
+Nginx and php-fpm are communicating via the TCP port 9000.
+
 ## Deploy with gcloud
 
 You can deploy the app by:

--- a/php-nginx/nginx.conf
+++ b/php-nginx/nginx.conf
@@ -37,6 +37,11 @@ http {
 
     keepalive_timeout  65;
 
+    upstream php-fpm {
+        server 127.0.0.1:9000 max_fails=3 fail_timeout=3s;
+        keepalive 8;
+    }
+
     server {
         listen       8080;
         root %%DOC_ROOT%%;
@@ -62,7 +67,12 @@ http {
         location ~ \.php$ {
           try_files $uri =404;
           fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-          fastcgi_pass unix:/var/run/php5-fpm.sock;
+          fastcgi_pass php-fpm;
+          fastcgi_buffer_size 16k;
+          fastcgi_buffers 256 16k;
+          fastcgi_busy_buffers_size 4064k;
+          fastcgi_max_temp_file_size 0;
+          fastcgi_keep_conn on;
           fastcgi_index index.php;
           include fastcgi_params;
         }

--- a/php-nginx/php-fpm.conf
+++ b/php-nginx/php-fpm.conf
@@ -176,7 +176,7 @@ group = www-data
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /var/run/php5-fpm.sock
+listen = 127.0.0.1:9000
 
 ; Set listen(2) backlog.
 ; Default Value: 65535 (-1 on FreeBSD and OpenBSD)
@@ -242,7 +242,7 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 5
+pm.max_children = 20
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
@@ -257,7 +257,7 @@ pm.min_spare_servers = 1
 ; The desired maximum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.max_spare_servers = 3
+pm.max_spare_servers = 4
 
 ; The number of seconds after which an idle process will be killed.
 ; Note: Used only when pm is set to 'ondemand'


### PR DESCRIPTION
When using the unix socket, I often saw 502 GATEWAY error. The log shows something like this:
```
2016/03/12 10:25:23 [error] 18#0: *6016 connect() to unix:/var/run/php5-fpm.sock failed (11: Resource temporarily unavailable) while connecting to upstream, client: 172.17.0.6, server: , request: "GET / HTTP/1.1", upstream: "fastcgi://unix:/var/run/php5-fpm.sock:", host: "tmatsuo-wordpress.appspot.com"
```

First I tried to raise net.core.somaxconn with sysctl, but it raises an error like "read only file system". The next attempt is using TCP socket instead of unix socket. With my experiments, TCP sockets are much stabler upon high load.

See also #65 