### PR TITLE
Allowing users to override php-fpm.conf.

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -103,6 +103,7 @@ COPY php.ini $PHP56_DIR/lib/php.ini
 COPY php.ini $PHP7_DIR/lib/php.ini
 COPY php-fpm.conf $PHP56_DIR/etc/php-fpm.conf
 COPY php-fpm.conf $PHP7_DIR/etc/php-fpm.conf
+RUN touch $PHP56_DIR/etc/php-fpm-user.conf $PHP7_DIR/etc/php-fpm-user.conf
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 COPY logrotate.app_engine /etc/logrotate.d/app_engine
 

--- a/php-nginx/entrypoint.sh
+++ b/php-nginx/entrypoint.sh
@@ -28,6 +28,9 @@ APP_NGINX_ADDITIONAL_CONF=${APP_DIR}/nginx-app.conf
 # replace our default main configuration file with this file.
 APP_NGINX_CONF=${APP_DIR}/nginx.conf
 
+# User provided php-fpm.conf
+PHP_FPM_CONF_OVERRIDE=${APP_DIR}/php-fpm.conf
+
 # Move user-provided nginx config files.
 
 if [ -f ${APP_NGINX_ADDITIONAL_CONF} ]; then
@@ -36,6 +39,12 @@ fi
 
 if [ -f ${APP_NGINX_CONF} ]; then
     mv ${APP_NGINX_CONF} ${NGINX_DIR}
+fi
+
+# Move user-provided php-fpm config file.
+
+if [ -f ${PHP_FPM_CONF_OVERRIDE} ]; then
+    mv ${PHP_FPM_CONF_OVERRIDE} ${PHP_DIR}/etc/php-fpm-user.conf
 fi
 
 # Configure memcached based session.

--- a/php-nginx/nginx.conf
+++ b/php-nginx/nginx.conf
@@ -39,7 +39,6 @@ http {
 
     upstream php-fpm {
         server 127.0.0.1:9000 max_fails=3 fail_timeout=3s;
-        keepalive 8;
     }
 
     server {
@@ -72,7 +71,6 @@ http {
           fastcgi_buffers 256 16k;
           fastcgi_busy_buffers_size 4064k;
           fastcgi_max_temp_file_size 0;
-          fastcgi_keep_conn on;
           fastcgi_index index.php;
           include fastcgi_params;
         }

--- a/php-nginx/php-fpm.conf
+++ b/php-nginx/php-fpm.conf
@@ -547,3 +547,4 @@ clear_env = no
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+include=${PHP_DIR}/etc/php-fpm-user.conf

--- a/testapps/php56_custom/php-fpm.conf
+++ b/testapps/php56_custom/php-fpm.conf
@@ -1,0 +1,6 @@
+; Custom values provided by user. We checked the number of processes
+; in our test.
+pm.max_children = 1
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 1

--- a/tests/CustomServingTest.php
+++ b/tests/CustomServingTest.php
@@ -33,6 +33,9 @@ class CustomServingTest extends \PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
+        exec('docker exec -t php56_custom find /var/log/app_engine '
+             . '-type f -exec tail {} \;', $output);
+        var_dump($output);
         exec('docker kill php56_custom');
         exec('docker rm php56_custom');
     }
@@ -81,5 +84,17 @@ class CustomServingTest extends \PHPUnit_Framework_TestCase
                             'pdo_sqlite.php status code');
         $this->assertContains('Hello pdo_sqlite',
                               $resp->getBody()->getContents());
+    }
+
+    public function testNumberOfPhpFpmChildren()
+    {
+        exec(
+            'docker exec -t php56_custom ps auxww|grep php-fpm|grep -v grep',
+            $output);
+        $this->assertEquals(
+            2, count($output),
+            'There should be only 2 php-fpm processes, actual: '
+            . count($output)
+        );
     }
 }

--- a/tests/PHP5ExtensionsTest.php
+++ b/tests/PHP5ExtensionsTest.php
@@ -35,6 +35,9 @@ class PHP5ExtensionsTest extends \PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
+        exec('docker exec -t php56_custom find /var/log/app_engine '
+             . '-type f -exec tail {} \;', $output);
+        var_dump($output);
         exec('docker kill php56_custom');
         exec('docker rm php56_custom');
     }

--- a/tests/PHP7ExtensionsTest.php
+++ b/tests/PHP7ExtensionsTest.php
@@ -35,6 +35,9 @@ class PHP7ExtensionsTest extends \PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
+        exec('docker exec -t php70_custom find /var/log/app_engine '
+             . '-type f -exec tail {} \;', $output);
+        var_dump($output);
         exec('docker kill php70_custom');
         exec('docker rm php70_custom');
     }

--- a/tests/ServingTest.php
+++ b/tests/ServingTest.php
@@ -32,6 +32,9 @@ class ServingTest extends \PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
+        exec('docker exec -t php56 find /var/log/app_engine '
+             . '-type f -exec tail {} \;', $output);
+        var_dump($output);
         exec('docker kill php56');
         exec('docker rm php56');
     }
@@ -59,6 +62,18 @@ class ServingTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $resp->getBody()->getContents(),
                             'phpinfo() should be disabled and the content'
                             . ' should be empty.');
+    }
+
+    public function testNumberOfPhpFpmChildren()
+    {
+        exec(
+            'docker exec -t php56 ps auxww|grep php-fpm|grep -v grep',
+            $output);
+        $this->assertGreaterThan(
+            2, count($output),
+            'There should be more than 2 php-fpm processes, actual: '
+            . count($output)
+        );
     }
 
     public function testPdoSqlite()


### PR DESCRIPTION
Also stopped using keepalive for fcgi in nginx.conf for test stability on travis, added debug output for local docker tests.

Fixes #71 
Related to #70 