### PR TITLE
Add APC-BC for APCu backwards compatibility

### DIFF
--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -174,6 +174,7 @@ composer.json:
 
 These extensions are enabled as builtin:
 
+- APCu
 - Bzip2
 - cURL
 - FPM
@@ -217,6 +218,10 @@ These extensions are only available with PHP 5.6:
 
 - suhosin (shared, but enabled by default)
 - gRPC (shared)
+
+These extensions are only available with PHP 7:
+
+- APCu-BC (builtin)
 
 ## Add something to php.ini
 

--- a/php-nginx/build-scripts/build_php70.sh
+++ b/php-nginx/build-scripts/build_php70.sh
@@ -40,14 +40,17 @@ curl -SL "https://pecl.php.net/get/mailparse" -o mailparse.tar.gz
 tar -zxf mailparse.tar.gz -C ${PHP_SRC}/ext/mailparse --strip-components=1
 rm mailparse.tar.gz
 
-# TODO: Use the stable version of apcu from pecl once available.
-# With the 5.1.2 source from the PECL, it doesn'r recognize the
-# --enable-apcu option.
-# mkdir -p ${PHP_SRC}/ext/apcu
-# curl -SL "https://pecl.php.net/get/apcu" -o apcu.tar.gz
-# tar -zxf apcu.tar.gz -C ${PHP_SRC}/ext/apcu --strip-components=1
-# rm apcu.tar.gz
-git clone https://github.com/krakjoe/apcu.git ${PHP_SRC}/ext/apcu
+# APCu
+mkdir -p ${PHP_SRC}/ext/apcu
+curl -SL "https://pecl.php.net/get/apcu-5.1.3.tgz" -o apcu.tar.gz
+tar -zxf apcu.tar.gz -C ${PHP_SRC}/ext/apcu --strip-components=1
+rm apcu.tar.gz
+
+# APC compatibility layer for APCu
+mkdir -p ${PHP_SRC}/ext/apcu-bc
+curl -SL "https://pecl.php.net/get/apcu_bc-1.0.3.tgz" -o apcu-bc.tar.gz
+tar -zxf apcu-bc.tar.gz -C ${PHP_SRC}/ext/apcu-bc --strip-components=1
+rm apcu-bc.tar.gz
 
 pushd ${PHP_SRC}
 rm -f configure
@@ -57,6 +60,7 @@ rm -f configure
     --with-config-file-scan-dir=$APP_DIR:${PHP7_DIR}/lib/conf.d \
     --disable-cgi \
     --disable-memcached-sasl \
+    --enable-apc \
     --enable-apcu \
     --enable-bcmath=shared \
     --enable-calendar=shared \

--- a/testapps/php70_custom/web/apc.php
+++ b/testapps/php70_custom/web/apc.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+$value = 'STRINGTOBECACHED';
+
+if (true === apc_store('artificialkey', $value)) {
+    echo('success storing in apc bc' . PHP_EOL);
+}
+
+if ($value === apc_fetch('artificialkey')) {
+    echo('success fetching from apc bc' . PHP_EOL);
+}
+
+if (true === apc_delete('artificialkey')) {
+    echo('success deleting from apc bc' . PHP_EOL);
+}
+
+if (true === apcu_add('artificialkey', $value)) {
+    echo('success storing in apcu' . PHP_EOL);
+}
+
+if ($value === apcu_fetch('artificialkey')) {
+    echo('success fetching from apcu' . PHP_EOL);
+}
+
+if (true === apcu_delete('artificialkey')) {
+    echo('success deleting from apcu' . PHP_EOL);
+}

--- a/tests/PHP7ExtensionsTest.php
+++ b/tests/PHP7ExtensionsTest.php
@@ -55,4 +55,17 @@ class PHP7ExtensionsTest extends \PHPUnit_Framework_TestCase
             $this->assertContains($ext, $loaded);
         }
     }
+
+    public function testApcIsAbleToExecuteCommonOperations()
+    {
+        $resp = $this->client->get('apc.php');
+        $body = $resp->getBody()->getContents();
+
+        $this->assertContains('success storing in apc bc', $body);
+        $this->assertContains('success fetching from apc bc', $body);
+        $this->assertContains('success deleting from apc bc', $body);
+        $this->assertContains('success storing in apcu', $body);
+        $this->assertContains('success fetching from apcu', $body);
+        $this->assertContains('success deleting from apcu', $body);
+    }
 }


### PR DESCRIPTION
The module emulates the `apc_*` api methods for compatibility.