### PR TITLE
Upgrade PHP to 5.6.21 & 7.0.6

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -76,14 +76,14 @@ COPY build-scripts/build_nginx.sh /build-scripts/build_nginx.sh
 RUN /bin/bash /build-scripts/build_nginx.sh
 
 # Build PHP 5.6
-ENV PHP56_VERSION=5.6.20
+ENV PHP56_VERSION=5.6.21
 COPY build-scripts/build_php56.sh /build-scripts/build_php56.sh
 COPY build-scripts/php5-parse_str_harden.patch \
     /build-scripts/php5-parse_str_harden.patch
 RUN /bin/bash /build-scripts/build_php56.sh
 
 # Build PHP 7.0
-ENV PHP70_VERSION=7.0.5
+ENV PHP70_VERSION=7.0.6
 COPY build-scripts/build_php70.sh /build-scripts/build_php70.sh
 COPY build-scripts/php7-parse_str_harden.patch \
     /build-scripts/php7-parse_str_harden.patch


### PR DESCRIPTION
We should think about a way to store away the precompiled binaries in a trusted way somehow and only compile them when needed.