### PR TITLE
Re-Add APP_DIR to ini scan folders

### DIFF
--- a/php-nginx/build-scripts/build_php56.sh
+++ b/php-nginx/build-scripts/build_php56.sh
@@ -68,7 +68,7 @@ rm -f configure
 ./buildconf --force
 ./configure \
     --prefix=$PHP56_DIR \
-    --with-config-file-scan-dir=${PHP56_DIR}/lib/conf.d \
+    --with-config-file-scan-dir=$APP_DIR:${PHP56_DIR}/lib/conf.d \
     --disable-cgi \
     --disable-memcached-sasl \
     --enable-apcu \

--- a/php-nginx/build-scripts/build_php70.sh
+++ b/php-nginx/build-scripts/build_php70.sh
@@ -63,7 +63,7 @@ patch -p1 < /build-scripts/php7-parse_str_harden.patch
 rm -f configure
 ./buildconf --force
 ./configure \
-    --prefix=$PHP7_DIR \
+    --prefix=$APP_DIR:$PHP7_DIR \
     --with-config-file-scan-dir=${PHP7_DIR}/lib/conf.d \
     --disable-cgi \
     --disable-memcached-sasl \


### PR DESCRIPTION
GoogleCloudPlatform/php-docker#108 removed the possibility
to add PHP modules on build, which fails composer when there's
platform requirements such as `ext-gd`.

This patch re-adds the additonal scan folder.