### PR TITLE
Removed vendor dir for cs check.

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,11 @@
+<?php
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->exclude('vendor')
+    ->in(__DIR__)
+;
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers(array('concat_with_spaces', 'unused_use', 'trailing_spaces', 'indentation'))
+    ->finder($finder)
+;

--- a/scripts/run_test_suite.sh
+++ b/scripts/run_test_suite.sh
@@ -21,8 +21,7 @@ set -ex
 # Run php-cs-fixer.
 # We want to fail fast for coding standard violations.
 
-vendor/bin/php-cs-fixer fix --dry-run --diff --level=psr2 \
-    --fixers=concat_with_spaces,unused_use,trailing_spaces,indentation .
+vendor/bin/php-cs-fixer fix --dry-run --diff .
 
 # Then build images.
 scripts/build_images.sh


### PR DESCRIPTION
The build is failing on our jenkins with an error:

```
PHP Parse error:  syntax error, unexpected 'self' (T_STRING) in /var/lib/jenkins/jobs/php-nginx docker image/workspace/vendor/symfony/process/Process.php on line 538
```

I'd remove the vendor dir.