### PR TITLE
fixes PHP_DIR in PATH

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -55,7 +55,7 @@ ENV NGINX_DIR=/opt/nginx \
     NGINX_VERSION=1.10.1 \
     PHP56_VERSION=5.6.22 \
     PHP70_VERSION=7.0.7 \
-    PATH=${PHP_DIR}/bin:$PATH
+    PATH=/opt/php/bin:$PATH
 
 # gpgkeys for verifying the tarballs
 COPY gpgkeys /gpgkeys

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -59,4 +59,11 @@ class VersionTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertTrue($checked, 'Failed to check the version is 5.6.x');
     }
+    public function testPhpInPath()
+    {
+        exec('docker run php56_70 env | grep "^PATH="', $output);
+        $grep = array_pop($output);
+        $paths = explode(':', str_replace('PATH=', '', $grep));
+        $this->assertContains('/opt/php/bin', $paths);
+    }
 }


### PR DESCRIPTION
`PATH=${PHP_DIR}/bin:$PATH` needs to be on a separate line, as it uses env variables declared in the same line.