### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Docker images for a managed VM runtime using PHP.
+# Docker image for the App Engine Flexible PHP runtime
 
-This repository contains experimental PHP runtime(s) for Google Cloud
-App Engine Managed VMs. It is not covered by any SLA or deprecation
-policy.  It may change at any time.
+This repository contains experimental PHP runtime(s) for Google App
+Engine Flexible Environment. It is not covered by any SLA or
+deprecation policy.  It may change at any time.
 
 ## Contributing changes
 

--- a/e2e/EndToEndTest.php
+++ b/e2e/EndToEndTest.php
@@ -50,7 +50,7 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
     {
         for ($i = 0; $i <= 3; $i++) {
             exec(
-                "gcloud -q preview app deploy --version $e2e_test_version"
+                "gcloud -q app deploy --version $e2e_test_version"
                 . " --project $project_id"
                 . ' testapps/php56_e2e/app.yaml',
                 $output,
@@ -70,7 +70,7 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
     {
         // TODO: check the return value and maybe retry?
         $cmd = sprintf(
-            'gcloud -q preview app versions delete --service default '
+            'gcloud -q app versions delete --service default '
             . '--project %s %s',
             getenv(self::PROJECT_ENV),
             getenv(self::VERSION_ENV)

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -264,7 +264,7 @@ Nginx and php-fpm are communicating via the TCP port 9000.
 You can deploy the app by:
 
 ```sh
-$ gcloud preview app deploy app.yaml
+$ gcloud app deploy
 ```
 
 ## Run it locally with docker

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -1,8 +1,8 @@
-# Docker image for a managed VM runtime using PHP and nginx.
+# Docker image for the App Engine Flexible PHP runtime with nginx
 
 This is an experimental PHP runtime for Google Cloud App Engine
-Flexible environment. It is not covered by any SLA or deprecation
-policy.  It may change at any time.
+Flexible Environment. It is not covered by any SLA or deprecation
+policy. It may change at any time.
 
 ## How to use
 


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.