### PR TITLE
Added `-f` option to `docker tag`

### DIFF
--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -48,7 +48,7 @@ build_image () {
         sed -i -e "s|FROM php-nginx|FROM ${BASE_IMAGE}|" "${SRC_DIR}/Dockerfile"
         gcloud -q alpha container builds create "${SRC_DIR}" --tag "${FULL_TAG}"
         gcloud docker pull "${FULL_TAG}"
-        docker tag "${FULL_TAG}" "${IMAGE}"
+        docker tag -f "${FULL_TAG}" "${IMAGE}"
     else
         # No credentials. Use local docker.
         docker build -t "${IMAGE}" "${DIR}"


### PR DESCRIPTION
On environments like jenkins, or local workstations, `docker tag` will fail if there's always the tag.