### PR TITLE
Provide a default nginx-app.conf

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -82,6 +82,7 @@ RUN mkdir -p $APP_DIR $LOG_DIR $UPLOAD_DIR $SESSION_SAVE_PATH \
 
 # Put config files into place.
 COPY nginx.conf fastcgi_params gzip_params $NGINX_DIR/conf/
+COPY nginx-app.conf $NGINX_USER_CONF_DIR
 COPY php.ini $PHP56_DIR/lib/php.ini
 COPY php.ini $PHP7_DIR/lib/php.ini
 COPY php-fpm.conf $PHP56_DIR/etc/php-fpm.conf

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -112,28 +112,26 @@ runtime_config:
 
 ## How to change nginx.config
 
-Put `nginx-app.conf` file which includes piece of nginx configuration
-for the `server` section in the project top directory. Then it will be
-moved to an appropriate directory and included from the main nginx
-configuration file.
+We put `nginx-app.conf` file which is included in the `server` section
+of the main configuration file. Here is the default configuration file
+which will likely just work with most of the modern web frameworks in
+simple cases.
 
-Assumption is that you don't often need to entirely modify the
-[default nginx file](nginx.conf).
-There is an `include` directive in the `server` section and your
-configuration file will be included there.
-
-Here is an example configuration for silex.
-
-nginx-app.conf:
+The default nginx-app.conf:
 
 ```ini
 location / {
-  # try to serve file directly, fallback to front controller
+  # try to serve files directly, fallback to the front controller
   try_files $uri /index.php$is_args$args;
 }
 ```
 
-I hope this mechanism can cover most of the web frameworks, but let us
+You might need to add some rewrite rules, or you might want to change
+the behavior. In those cases, put a file named `nginx-app.conf` in the
+project root directory. Then the runtime will override the default
+file with the file you provided.
+
+I hope this mechanism can cover most of your use cases, but let us
 know if you found otherwise.
 
 ## Change the PHP version

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -112,12 +112,9 @@ runtime_config:
 
 ## How to change nginx.config
 
-We put `nginx-app.conf` file which is included in the `server` section
-of the main configuration file. Here is the default configuration file
-which will likely just work with most of the modern web frameworks in
-simple cases.
-
-The default nginx-app.conf:
+An `nginx-app.conf` configuration file is included in the server
+section of the main nginx configuration file. The default
+configuration file looks like this:
 
 ```ini
 location / {
@@ -126,10 +123,22 @@ location / {
 }
 ```
 
-You might need to add some rewrite rules, or you might want to change
-the behavior. In those cases, put a file named `nginx-app.conf` in the
-project root directory. Then the runtime will override the default
-file with the file you provided.
+To define a custom configuration file, put a file named
+`nginx-app.conf` in the project root directory. The runtime will
+override the default file with the file you provided.
+
+By default, index.php is used as the framework front controller. You
+may need to change this to something different for your project. The
+Symfony framework, for instance, uses app.php instead of index.php.
+
+Here is an example `nginx-app.conf` for the Symfony framework:
+
+```ini
+location / {
+  # try to serve files directly, fallback to the front controller
+  try_files $uri /app.php$is_args$args;
+}
+```
 
 I hope this mechanism can cover most of your use cases, but let us
 know if you found otherwise.

--- a/php-nginx/nginx-app.conf
+++ b/php-nginx/nginx-app.conf
@@ -1,0 +1,4 @@
+location / {
+  # try to serve files directly, fallback to the front controller
+  try_files $uri /index.php$is_args$args;
+}

--- a/tests/ServingTest.php
+++ b/tests/ServingTest.php
@@ -53,6 +53,16 @@ class ServingTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Hello World', $resp->getBody()->getContents());
     }
 
+    public function testNonExistentPath()
+    {
+        // Non-existent paths should be served by the `index.php` too, thanks
+        // to the default nginx-app.conf.
+        $resp = $this->client->get('non-existent-path');
+        $this->assertEquals('200', $resp->getStatusCode(),
+                            'non-existent-path status code');
+        $this->assertContains('Hello World', $resp->getBody()->getContents());
+    }
+
     public function testPhpInfo()
     {
         // Access to phpinfo.php, while phpinfo() is disabled by default.


### PR DESCRIPTION
Note: with this image, we can just remove the `nginx-app.conf` in our most of the (probably all?) sample applications.