### PR TITLE
Switch base image from base to debian8

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -14,7 +14,7 @@
 
 # Dockerfile for PHP 5.6 using nginx as the webserver.
 
-FROM gcr.io/google_appengine/base
+FROM gcr.io/google_appengine/debian8
 
 # persistent / runtime deps
 RUN apt-get update && \


### PR DESCRIPTION
The newest debian images for jessie (gcr.io/google-appengine/debian8:latest) now has all the extra env variables and ca-certs that were in base.

cc @dlorenc 