### PR TITLE
adding license tests to structure tests

### DIFF
--- a/php-nginx/php-nginx.yaml
+++ b/php-nginx/php-nginx.yaml
@@ -6,3 +6,6 @@ commandTests:
   - name: "version"
     command: ["php", "-v"]
     expectedOutput: ["PHP 5\\.6.*"]
+licenseTests:
+  - debian: true
+    files: []


### PR DESCRIPTION
License tests are automated tests to check that all packages installed in the image conform to Google's open source licensing stardards. Check out https://github.com/GoogleCloudPlatform/runtimes-common/blob/master/structure_tests/licenses_test.go (and the corresponding README) for more details.