### PR TITLE
Version upgrades

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -58,9 +58,9 @@ ENV NGINX_DIR=/opt/nginx \
     NGINX_USER_CONF_DIR=/etc/nginx/conf.d \
     UPLOAD_DIR=/upload \
     SESSION_SAVE_PATH=/tmp/sessions \
-    NGINX_VERSION=1.10.1 \
-    PHP56_VERSION=5.6.28 \
-    PHP70_VERSION=7.0.13 \
+    NGINX_VERSION=1.10.2 \
+    PHP56_VERSION=5.6.29 \
+    PHP70_VERSION=7.0.14 \
     PATH=/opt/php/bin:$PATH \
     WWW_HOME=/var/www
 

--- a/php-nginx/build-scripts/build_php56.sh
+++ b/php-nginx/build-scripts/build_php56.sh
@@ -34,11 +34,6 @@ tar -zxf php.tar.gz -C ${PHP_SRC} --strip-components=1
 rm php.tar.gz
 rm php.tar.gz.asc
 
-mkdir -p ${PHP_SRC}/ext/memcached
-curl -SL "http://pecl.php.net/get/memcached" -o memcached.tar.gz
-tar -zxf memcached.tar.gz -C ${PHP_SRC}/ext/memcached --strip-components=1
-rm memcached.tar.gz
-
 rm -rf ${PHP_SRC}/ext/json
 mkdir -p ${PHP_SRC}/ext/json
 curl -SL "https://pecl.php.net/get/jsonc" -o jsonc.tar.gz
@@ -80,8 +75,6 @@ rm -f configure
     --enable-intl=shared \
     --enable-mailparse \
     --enable-mbstring \
-    --enable-memcached=shared \
-    --enable-memcached-sasl \
     --enable-mysqlnd \
     --enable-opcache \
     --enable-pcntl=shared \
@@ -128,9 +121,10 @@ mkdir -p ${PHP56_DIR}/lib/conf.d
 
 # Install shared extensions
 ${PHP56_DIR}/bin/pecl install memcache
+${PHP56_DIR}/bin/pecl install memcached
 ${PHP56_DIR}/bin/pecl install mongodb
 ${PHP56_DIR}/bin/pecl install redis-2.2.8
-${PHP56_DIR}/bin/pecl install grpc-beta
+${PHP56_DIR}/bin/pecl install grpc
 
 rm -rf /tmp/pear
 

--- a/php-nginx/build-scripts/build_php70.sh
+++ b/php-nginx/build-scripts/build_php70.sh
@@ -48,7 +48,7 @@ rm mailparse.tar.gz
 
 # APCu
 mkdir -p ${PHP_SRC}/ext/apcu
-curl -SL "https://pecl.php.net/get/apcu-5.1.4.tgz" -o apcu.tar.gz
+curl -SL "https://pecl.php.net/get/apcu" -o apcu.tar.gz
 tar -zxf apcu.tar.gz -C ${PHP_SRC}/ext/apcu --strip-components=1
 rm apcu.tar.gz
 


### PR DESCRIPTION
`--enable-memcached-sasl` option is actually not needed because the default is enabled. Now it's just installing from pecl which should be fine. It will also remove the warnings about missing so files at startup.