### PR TITLE
Added /app to the --with-config-file-scan-dir option.

### DIFF
--- a/deb-package-builder/debian/rules.in
+++ b/deb-package-builder/debian/rules.in
@@ -12,7 +12,7 @@ override_dh_auto_configure:
 	&& ./buildconf --force \
 	&& dh_auto_configure -- --prefix=/opt/php${SHORT_VERSION} \
 	--with-config-file-path=/opt/php${SHORT_VERSION}/lib \
-	--with-config-file-scan-dir=/opt/php${SHORT_VERSION}/lib/ext.enabled:/opt/php${SHORT_VERSION}/lib/conf.d \
+	--with-config-file-scan-dir=/opt/php${SHORT_VERSION}/lib/ext.enabled:/opt/php${SHORT_VERSION}/lib/conf.d:/app \
 	--disable-cgi \
 	--enable-bcmath=shared \
 	--enable-calendar=shared \


### PR DESCRIPTION
This is intentionally not using the environment variable.

To change the `APP_DIR` env var, first you need to change it in our PHP
binaries, upload those packages, then change it in
`php-nginx/Dockerfile`.