### PR TITLE
Changed the name of the PHP debian packages.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ machine:
     PHP_DOCKER_GOOGLE_CREDENTIALS: ${HOME}/credentials.json
     GOOGLE_PROJECT_ID: php-mvm-a
     TAG: circle-${CIRCLE_BUILD_NUM}
+    RUNTIME_DISTRIBUTION: gcp-php-runtime-jessie-unstable
 
 dependencies:
   override:

--- a/deb-package-builder/debian/README.debian
+++ b/deb-package-builder/debian/README.debian
@@ -2,6 +2,7 @@ gcp-php for Debian
 -------------------
 
 This package contains a PHP installation for a Google Cloud Platform
-runtime image. It installs into the /opt/php/php-{VERSION} directory.
+runtime image. It installs into the /opt/php/phpXY (where X = Major
+version and Y = Minor version of PHP) directory.
 
  -- Takashi Matsuo <tmatsuo@google.com>  Thu, 15 Dec 2016 09:47:00 -0700

--- a/deb-package-builder/debian/control.in
+++ b/deb-package-builder/debian/control.in
@@ -1,4 +1,4 @@
-Source: gcp-php-${PHP_VERSION}
+Source: gcp-php${SHORT_VERSION}
 Section: unknown
 Priority: optional
 Maintainer: Takashi Matsuo <tmatsuo@google.com>
@@ -6,10 +6,7 @@ Build-Depends: debhelper (>= 8.0.0), devscripts, build-essential, libparse-debco
 Standards-Version: 3.9.4
 Homepage: http://php.net/
 
-Package: gcp-php-${PHP_VERSION}
+Package: gcp-php${SHORT_VERSION}
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, gettext, libbz2-1.0, libicu52, libjpeg62-turbo, libmcrypt4, libmemcached11, libmemcachedutil2, libpcre3, libpng12-0, libpq5, libreadline6, librecode0, libsasl2-modules, libsqlite3-0, libxml2, libxslt1.1, openssl, zlib1g
-Provides: gcp-php${SHORT_VERSION}
-Conflicts: gcp-php${SHORT_VERSION}
-Replaces: gcp-php${SHORT_VERSION}
 Description: PHP for Google Cloud Platform runtimes

--- a/deb-package-builder/debian/rules.in
+++ b/deb-package-builder/debian/rules.in
@@ -59,11 +59,11 @@ override_dh_auto_configure:
 override_dh_auto_test:
 
 override_dh_auto_install:
-	INSTALL_ROOT=$(CURDIR)/debian/gcp-php-${PHP_VERSION} dh_auto_install \
-	&& rm -rf $(CURDIR)/debian/gcp-php-${PHP_VERSION}/etc \
-	&& find $(CURDIR)/debian/gcp-php-${PHP_VERSION} -name .channels -prune \
-		-exec rm -rf '{}' \; \
-	&& find $(CURDIR)/debian/gcp-php-${PHP_VERSION} -name .registry -prune \
-		-exec rm -rf '{}' \; \
-	&& find $(CURDIR)/debian/gcp-php-${PHP_VERSION} -type f -name ".*" \
+	INSTALL_ROOT=$(CURDIR)/debian/gcp-php${SHORT_VERSION} dh_auto_install \
+	&& rm -rf $(CURDIR)/debian/gcp-php${SHORT_VERSION}/etc \
+	&& find $(CURDIR)/debian/gcp-php${SHORT_VERSION} -name .channels \
+		-prune -exec rm -rf '{}' \; \
+	&& find $(CURDIR)/debian/gcp-php${SHORT_VERSION} -name .registry \
+		-prune -exec rm -rf '{}' \; \
+	&& find $(CURDIR)/debian/gcp-php${SHORT_VERSION} -type f -name ".*" \
 		-exec rm '{}' \;

--- a/php-nginx/composer.sh
+++ b/php-nginx/composer.sh
@@ -43,14 +43,14 @@ EOF
     if [ "${PHP_VERSION}" == "7.0" ]; then
         apt-get -y update
         /bin/bash /build-scripts/install_php70.sh
-        apt-get remove -y gcp-php-${PHP56_VERSION}
+        apt-get remove -y gcp-php56
         rm -rf /var/lib/apt/lists/*
     fi
 
     if [ "${PHP_VERSION}" == "7.1" ]; then
         apt-get -y update
         /bin/bash /build-scripts/install_php71.sh
-        apt-get remove -y gcp-php-${PHP56_VERSION}
+        apt-get remove -y gcp-php56
         rm -rf /var/lib/apt/lists/*
     fi
 


### PR DESCRIPTION
Before this PR, the name of the PHP debian packages are like:

gcp-php-5.6.30
gcp-php-7.0.15

and they provide virtual packages like gcp-php56, gcp-php70.

It turned out it is problematic when we have multiple patch versions
in our repo.

For example, if we have these two packages:

gcp-php-7.0.14_7.0.14-2
gcp-php-7.0.15_7.0.15-1

in a single repo, the following command fails:

```
$ apt-get -y install gcp-php70
```

because when there are multiple candidates for a virtual package, apt
can't decide which to pick, so it fails.

So we need to change the package names as follows:

gcp-php56_5.6.30-1
gcp-php70_7.0.15-1

so that our repo will have only one package for each minor versions.