### PR TITLE
Add packages.yml configuration for building the php packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/vendor
 .php_cs.cache
+deb-package-builder/pkg

--- a/deb-package-builder/packages.yml
+++ b/deb-package-builder/packages.yml
@@ -1,0 +1,10 @@
+name: gcp-php
+
+repository: gcp-php-runtime-jessie
+
+stable_tag: php-cloud-eng.stable:true
+
+versions:
+  - 5.6.30-1
+  - 7.0.15-1
+  - 7.1.1-1


### PR DESCRIPTION
Allows us the maintain the list of versions in code and utilize the same package build scripts as the ruby package builders.