### PR TITLE
Set SERVER_NAME to the same value as HTTP_HOST.

### DIFF
--- a/php-nginx/fastcgi_params
+++ b/php-nginx/fastcgi_params
@@ -33,7 +33,7 @@ fastcgi_param   REMOTE_ADDR             $http_x_real_ip;
 fastcgi_param   REMOTE_PORT             $remote_port;
 fastcgi_param   SERVER_ADDR             $server_addr;
 fastcgi_param   SERVER_PORT             $server_port;
-fastcgi_param   SERVER_NAME             $server_name;
+fastcgi_param   SERVER_NAME             $http_host;
 
 fastcgi_param   HTTPS                   $fastcgi_https;
 


### PR DESCRIPTION
It is more friendly for programs that expect the correct server name in `$_SERVER['SERVER_NAME']`.