### PR TITLE
Make the CANDIDATE_TAG usable as cloud-build version [a-z0-9\-]

### DIFF
--- a/scripts/jenkins_build.sh
+++ b/scripts/jenkins_build.sh
@@ -26,7 +26,7 @@ export SKIP_CS_CHECK=true
 export INSTALL_GCLOUD=true
 export BUILDER_TARGET_IMAGE="gcr.io/${PRODUCTION_DOCKER_NAMESPACE}/php"
 
-CANDIDATE_TAG=`date +%Y-%m-%d_%H_%M`
+CANDIDATE_TAG=`date +%Y-%m-%d-%H-%M`
 echo "CANDIDATE_TAG:${CANDIDATE_TAG}"
 export TAG=${CANDIDATE_TAG}
 


### PR DESCRIPTION
We're now reusing the CANDIDATE_TAG environment variable as the TAG environment variable. The TAG environment variable is used the the end-to-end test as the app version. This app version can only contain lowercase letters, digits, and hyphens. The fix here is to change the underscores to hyphens.