### PR TITLE
Fixed a wrong error_log distination

### DIFF
--- a/php-nginx/php-cli.ini
+++ b/php-nginx/php-cli.ini
@@ -585,8 +585,8 @@ html_errors = Off
 ; http://php.net/error-log
 ; Example:
 ;error_log = php_errors.log
-; Log errors to syslog (Event Log on Windows).
-error_log = STDERR
+; Log errors to stderr
+error_log = /dev/stderr
 
 ;windows.show_crt_warning
 ; Default value: 0

--- a/php-nginx/php.ini
+++ b/php-nginx/php.ini
@@ -586,7 +586,7 @@ html_errors = Off
 ; Example:
 ;error_log = php_errors.log
 ; Log errors to stderr
-error_log = STDERR
+error_log = /dev/stderr
 
 ;windows.show_crt_warning
 ; Default value: 0


### PR DESCRIPTION
I noticed the php cli is create a file named `STDERR`.
It worked for php-fpm because it can not open the file `STDERR` and fell back to stderr. We should use `/dev/stderr`.