### PR TITLE
Adding tests for checking if the current versions are the latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ install:
 - scripts/install_test_dependencies.sh
 
 script:
-- scripts/run_test_suite.sh
+- scripts/check_versions.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,15 @@ branches:
   only:
     - master
 
+notifications:
+  email:
+    recipients:
+      - php-cloud-eng@google.com
+      - tmatsuo@google.com
+
 env:
   global:
+    - INSTALL_GCLOUD=true
     - GCLOUD_DIR=${HOME}/gcloud
     - PATH=${GCLOUD_DIR}/google-cloud-sdk/bin:${PATH}
     - PHP_DOCKER_GOOGLE_CREDENTIALS=${TRAVIS_BUILD_DIR}/credentials.json

--- a/check-versions/cloudbuild.yaml.in
+++ b/check-versions/cloudbuild.yaml.in
@@ -1,0 +1,4 @@
+steps:
+        - name: gcr.io/cloud-builders/docker
+          args: ['pull', 'gcr.io/google-appengine/php']
+        - name: ${TEST_RUNNER}

--- a/check-versions/composer.json
+++ b/check-versions/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "guzzlehttp/guzzle": "^6.2"
+    }
+}

--- a/check-versions/composer.lock
+++ b/check-versions/composer.lock
@@ -1,0 +1,240 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "8840215128cf6bd4d1ae96f7fcec71aa",
+    "content-hash": "7a12869adba2f709560fabbdf077d9f5",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-10-08 15:01:37"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20 10:07:11"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2016-06-24 23:00:38"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06 14:39:51"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/check-versions/phpunit.xml.dist
+++ b/check-versions/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/check-versions/tests/VersionTest.php
+++ b/check-versions/tests/VersionTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use GuzzleHttp\Client;
+
+class VersionTest extends \PHPUnit_Framework_TestCase
+{
+    private static $versions;
+
+    public static function setUpBeforeClass()
+    {
+        self::$versions = array();
+        $client = new Client(['base_uri' => 'http://www.php.net']);
+        $response = $client->request('GET', '/downloads.php');
+        $body = $response->getBody();
+
+        $pattern = '/PHP (5\.6\.\d+)/';
+        if (preg_match($pattern, $body, $matches)) {
+            self::$versions['php56'] = $matches[1];
+        } else {
+            self::$versions['php56'] =
+                'Failed to detect the latest PHP56 version';
+        }
+
+        $pattern = '/PHP (7\.0\.\d+)/';
+        if (preg_match($pattern, $body, $matches)) {
+            self::$versions['php70'] = $matches[1];
+        } else {
+            self::$versions['php70'] =
+                'Failed to detect the latest PHP70 version';
+        }
+
+        $pattern = '/PHP (7\.1\.\d+)/';
+        if (preg_match($pattern, $body, $matches)) {
+            self::$versions['php71'] = $matches[1];
+        } else {
+            self::$versions['php71'] =
+                'Failed to detect the latest PHP70 version';
+        }
+
+        $client = new Client(['base_uri' => 'http://nginx.org']);
+        $response = $client->request('GET', '/');
+        $body = $response->getBody();
+
+        $pattern = '/nginx-(1\.10\.\d+)/';
+        if (preg_match($pattern, $body, $matches)) {
+            self::$versions['nginx'] = $matches[1];
+        } else {
+            self::$versions['nginx'] =
+                'Failed to detect the latest nginx stable version';
+        }
+    }
+
+    public function testPHP56Version()
+    {
+        $output = exec(
+            'docker run -t gcr.io/google-appengine/php bash -c '
+            . '\'apt-get update && apt-cache madison gcp-php56\'');
+        $pattern = '/(5\.6\.\d+)/';
+        if (preg_match($pattern, $output, $matches)) {
+            $this->assertEquals($matches[1], self::$versions['php56']);
+        } else {
+            $this->fail('Failed to detect the current php56 version');
+        }
+    }
+
+    public function testPHP70Version()
+    {
+        $output = exec(
+            'docker run -t gcr.io/google-appengine/php bash -c '
+            . '\'apt-get update && apt-cache madison gcp-php70\'');
+        $pattern = '/(7\.0\.\d+)/';
+        if (preg_match($pattern, $output, $matches)) {
+            $this->assertEquals($matches[1], self::$versions['php70']);
+        } else {
+            $this->fail('Failed to detect the current php70 version');
+        }
+    }
+
+    public function testPHP71Version()
+    {
+        $output = exec(
+            'docker run -t gcr.io/google-appengine/php bash -c '
+            . '\'apt-get update && apt-cache madison gcp-php71\'');
+        $pattern = '/(7\.1\.\d+)/';
+        if (preg_match($pattern, $output, $matches)) {
+            $this->assertEquals($matches[1], self::$versions['php71']);
+        } else {
+            $this->fail('Failed to detect the current php71 version');
+        }
+    }
+
+    public function testNginxVersion()
+    {
+        $output = exec(
+            '/usr/bin/docker run -t gcr.io/google-appengine/php'
+            . ' /opt/nginx/sbin/nginx -v');
+        $pattern = '/nginx\/(\d+\.\d+\.\d+)/';
+        if (preg_match($pattern, $output, $matches)) {
+            $this->assertEquals($matches[1], self::$versions['nginx']);
+        } else {
+            $this->fail('Failed to detect the current nginx version');
+        }
+    }
+}

--- a/check-versions/tests/bootstrap.php
+++ b/check-versions/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/cloudbuild-test-runner/Dockerfile
+++ b/cloudbuild-test-runner/Dockerfile
@@ -21,7 +21,8 @@ ENV PATH=${PATH}:/opt/bin:/opt/gcloud/google-cloud-sdk/bin
 
 # Install PHP and tools
 RUN apk add php5 php5-openssl php5-json php5-phar php5-dom php5-bcmath \
-    php5-zip php5-ctype wget ca-certificates coreutils unzip --update && \
+    php5-zip php5-ctype wget ca-certificates coreutils unzip docker \
+    --update && \
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
     php -r "if (hash_file('SHA384', 'composer-setup.php') === rtrim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
     php composer-setup.php --filename=composer --install-dir=/opt/bin && \

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2015 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+if [ ! -f "${PHP_DOCKER_GOOGLE_CREDENTIALS}" ]; then
+    echo 'Please set PHP_DOCKER_GOOGLE_CREDENTIALS envvar.'
+    exit 1
+fi
+
+php scripts/dump_credentials.php
+
+# Use the service account for gcloud operations.
+gcloud auth activate-service-account \
+    --key-file "${PHP_DOCKER_GOOGLE_CREDENTIALS}"
+
+SRC_TMP=$(mktemp -d)
+
+# build the php test runner and export the name
+export TEST_RUNNER="gcr.io/${GOOGLE_PROJECT_ID}/php-test-runner:${TAG}"
+
+gcloud -q container builds submit --tag "${TEST_RUNNER}" \
+    cloudbuild-test-runner
+
+SRC_DIR="${SRC_TMP}/check-versions"
+cp -R check-versions ${SRC_DIR}
+envsubst < "${SRC_DIR}/cloudbuild.yaml.in" > "${SRC_DIR}/cloudbuild.yaml"
+
+gcloud -q container builds submit ${SRC_DIR} \
+    --config "${SRC_DIR}/cloudbuild.yaml"


### PR DESCRIPTION
Now it only checks micro versoins of php56, php70, php71, and nginx.
My plan is to run this on Travis with its Cron feature.