### PR TITLE
Add download_from_tarball function to the extension builders.

### DIFF
--- a/deb-package-builder/extensions/functions.sh
+++ b/deb-package-builder/extensions/functions.sh
@@ -32,3 +32,29 @@ download_from_pecl()
     tar zxvf ${PNAME}-${PACKAGE_VERSION}.orig.tar.gz \
         -C ${PACKAGE_DIR} --strip-components=1
 }
+
+download_from_tarball()
+{
+    # Download the source code, rename, extract it for debian package
+    # Usage:
+    # download_from_tarball https://github.com/phalcon/cphalcon/archive/v3.0.4.tar.gz 3.0.4
+    if [ -z "$1" ]; then
+        echo 'missing argument for download_from_tarball'
+        exit $E_PARAM_ERR
+    fi
+    if [ -z "$2" ]; then
+        echo 'missing argument for download_from_tarball'
+        exit $E_PARAM_ERR
+    fi
+
+    EXT_VERSION=$2
+    PACKAGE_VERSION="${EXT_VERSION}-${PHP_VERSION}"
+    PACKAGE_FULL_VERSION="${EXT_VERSION}-${FULL_VERSION}"
+    PACKAGE_DIR=${PNAME}-${PACKAGE_VERSION}
+
+    # Download the file
+    curl -L $1 -o ${PNAME}-${PACKAGE_VERSION}.orig.tar.gz
+    mkdir -p ${PACKAGE_DIR}
+    tar zxvf ${PNAME}-${PACKAGE_VERSION}.orig.tar.gz \
+        -C ${PACKAGE_DIR} --strip-components=1
+}


### PR DESCRIPTION
If an extension's source is not available from PECL, you can use this
function to download and unzip the tarball from an arbitrary url.

Usage:
download_from_tarball <url> <version>
downlaod_from_tarball https://github.com/phalcon/cphalcon/archive/v3.0.4.tar.gz 3.0.4

It puts the source code in the same directory structure that downloading from PECL creates.