### PR TITLE
Automatically install all of our pre-built extensions

### DIFF
--- a/php-nginx/build-scripts/install_php56.sh
+++ b/php-nginx/build-scripts/install_php56.sh
@@ -21,6 +21,9 @@ set -xe
 apt-get install -y \
         gcp-php56 \
         gcp-php56-apcu \
+        gcp-php56-cassandra \
+        gcp-php56-ev \
+        gcp-php56-event \
         gcp-php56-grpc \
         gcp-php56-imagick \
         gcp-php56-json \
@@ -28,6 +31,10 @@ apt-get install -y \
         gcp-php56-memcache \
         gcp-php56-memcached \
         gcp-php56-mongodb \
+        gcp-php56-oauth \
+        gcp-php56-phalcon \
+        gcp-php56-pq \
+        gcp-php56-rdkafka \
         gcp-php56-redis \
         gcp-php56-suhosin
 

--- a/php-nginx/build-scripts/install_php70.sh
+++ b/php-nginx/build-scripts/install_php70.sh
@@ -22,11 +22,18 @@ apt-get install -y \
         gcp-php70 \
         gcp-php70-apcu \
         gcp-php70-apcu-bc \
+        gcp-php70-cassandra \
+        gcp-php70-ev \
+        gcp-php70-event \
         gcp-php70-grpc \
         gcp-php70-imagick \
         gcp-php70-mailparse \
         gcp-php70-memcached \
         gcp-php70-mongodb \
+        gcp-php70-oauth \
+        gcp-php70-phalcon \
+        gcp-php70-pq \
+        gcp-php70-rdkafka \
         gcp-php70-redis
 
 # Enable some extensions for backward compatibility

--- a/php-nginx/build-scripts/install_php71.sh
+++ b/php-nginx/build-scripts/install_php71.sh
@@ -22,11 +22,17 @@ apt-get install -y \
         gcp-php71 \
         gcp-php71-apcu \
         gcp-php71-apcu-bc \
+        gcp-php71-cassandra \
+        gcp-php71-ev \
+        gcp-php71-event \
         gcp-php71-grpc \
         gcp-php71-imagick \
         gcp-php71-mailparse \
         gcp-php71-memcached \
         gcp-php71-mongodb \
+        gcp-php71-oauth \
+        gcp-php71-pq \
+        gcp-php71-rdkafka \
         gcp-php71-redis
 
 # Enable some extensions for backward compatibility

--- a/testapps/php56_extensions/Dockerfile.in
+++ b/testapps/php56_extensions/Dockerfile.in
@@ -13,13 +13,3 @@
 # limitations under the License.
 
 FROM ${BASE_IMAGE}
-
-RUN apt-get update -y && \
-    apt-get install -y \
-        gcp-php56-ev \
-        gcp-php56-event \
-        gcp-php56-oauth \
-        gcp-php56-pq \
-        gcp-php56-rdkafka \
-        gcp-php56-phalcon \
-        gcp-php56-cassandra

--- a/testapps/php70_extensions/Dockerfile.in
+++ b/testapps/php70_extensions/Dockerfile.in
@@ -13,13 +13,3 @@
 # limitations under the License.
 
 FROM ${BASE_IMAGE}
-
-RUN apt-get update -y && \
-    apt-get install -y \
-        gcp-php70-ev \
-        gcp-php70-event \
-        gcp-php70-oauth \
-        gcp-php70-pq \
-        gcp-php70-rdkafka \
-        gcp-php70-phalcon \
-        gcp-php70-cassandra

--- a/testapps/php71_extensions/Dockerfile.in
+++ b/testapps/php71_extensions/Dockerfile.in
@@ -13,12 +13,3 @@
 # limitations under the License.
 
 FROM ${BASE_IMAGE}
-
-RUN apt-get update -y && \
-    apt-get install -y \
-        gcp-php71-ev \
-        gcp-php71-event \
-        gcp-php71-oauth \
-        gcp-php71-pq \
-        gcp-php71-rdkafka \
-        gcp-php71-cassandra


### PR DESCRIPTION
Automatically install our extensions built as debian packages when we install php.

This will allow the users to only have to enable them by adding a custom `php.ini` file rather than forcing them to create a Dockerfile.