### PR TITLE
Fix image name for jenkins build.

### DIFF
--- a/scripts/jenkins_build.sh
+++ b/scripts/jenkins_build.sh
@@ -44,7 +44,7 @@ scripts/run_test_suite.sh
 
 unset CLOUDSDK_ACTIVE_CONFIG_NAME
 
-IMAGE_NAME="gcr.io/${GOOGLE_PROJECT_ID}/php-nginx:${TAG}"
+IMAGE_NAME="gcr.io/${GOOGLE_PROJECT_ID}/php:${TAG}"
 
 PROD_IMAGE_NAME="gcr.io/${PRODUCTION_DOCKER_NAMESPACE}/php:${TAG}"
 

--- a/scripts/jenkins_build.sh
+++ b/scripts/jenkins_build.sh
@@ -40,12 +40,4 @@ gcloud info
 scripts/install_test_dependencies.sh
 scripts/run_test_suite.sh
 
-# Push the image to production namespace with timestamped tag.
-
 unset CLOUDSDK_ACTIVE_CONFIG_NAME
-
-IMAGE_NAME="gcr.io/${GOOGLE_PROJECT_ID}/php:${TAG}"
-
-PROD_IMAGE_NAME="gcr.io/${PRODUCTION_DOCKER_NAMESPACE}/php:${TAG}"
-
-gcloud -q beta container images add-tag "${IMAGE_NAME}" "${PROD_IMAGE_NAME}"


### PR DESCRIPTION
We renamed the test image to php from php-nginx and updated the circle ci config previously.

This fixes the jenkins build (for testing new package versions)