### PR TITLE
Making sure the auto_prepend_file is not executed by root.

### DIFF
--- a/php-nginx/composer.sh
+++ b/php-nginx/composer.sh
@@ -74,7 +74,7 @@ EOF
     rm -rf ${APP_DIR}/vendor
 
     # Auto install extensions
-    php /tmp/install_extensions.php ${APP_DIR}/composer.json ${PHP_DIR}/lib/conf.d/extensions.ini ${PHP_VERSION}
+    php -d auto_prepend_file='' /tmp/install_extensions.php ${APP_DIR}/composer.json ${PHP_DIR}/lib/conf.d/extensions.ini ${PHP_VERSION}
 
     # Run Composer.
     cd ${APP_DIR} && \


### PR DESCRIPTION
I have a plan for automatically configure `auto_prepend_file` for error reporting. When the `auto_prepend_file` for the error reporting is executed by root, internally it creates semaphore and shared kernel memory owned by root, and potentially it will prevent the daemon from running as www-data later.