### PR TITLE
Added empty auto_prepend_file.

### DIFF
--- a/php-nginx/composer.sh
+++ b/php-nginx/composer.sh
@@ -74,11 +74,11 @@ EOF
     rm -rf ${APP_DIR}/vendor
 
     # Auto install extensions
-    php /tmp/install_extensions.php ${APP_DIR}/composer.json ${PHP_DIR}/lib/conf.d/extensions.ini ${PHP_VERSION}
+    php -d auto_prepend_file='' /tmp/install_extensions.php ${APP_DIR}/composer.json ${PHP_DIR}/lib/conf.d/extensions.ini ${PHP_VERSION}
 
     # Run Composer.
     cd ${APP_DIR} && \
-        su -m www-data -c "php /usr/local/bin/composer \
+        su -m www-data -c "php -d auto_prepend_file='' /usr/local/bin/composer \
           install \
           --no-scripts \
           --no-dev \


### PR DESCRIPTION
After removing the vendor dir, auto_prepend_file with our error reporting fails to bootstrap for those PHP calls.

For now I'd like to keep the Stackdriver integration just an opt-in feature with some custom config files. Later we'll design the automatic enabler with the Runtime Builder.