### PR TITLE
Runtime Builder improvement

### DIFF
--- a/builder/gen-dockerfile/Dockerfile.in
+++ b/builder/gen-dockerfile/Dockerfile.in
@@ -17,12 +17,6 @@
 
 FROM ${BASE_IMAGE}
 
-ARG BUILDER_TARGET_IMAGE="gcr.io/google-appengine/php"
-ARG BUILDER_TARGET_TAG="latest"
-
-ENV BUILDER_TARGET_IMAGE=${BUILDER_TARGET_IMAGE}
-ENV BUILDER_TARGET_TAG=${BUILDER_TARGET_TAG}
-
 RUN mkdir /builder
 COPY . /builder
 COPY errors.ini ${PHP_DIR}/lib/conf.d/

--- a/builder/gen-dockerfile/cloudbuild.yaml.in
+++ b/builder/gen-dockerfile/cloudbuild.yaml.in
@@ -1,6 +1,6 @@
 steps:
         - name: gcr.io/cloud-builders/docker
-          args: ['build', '-t', '${IMAGE}', '--build-arg', 'BUILDER_TARGET_IMAGE=${BUILDER_TARGET_IMAGE}', '--build-arg', 'BUILDER_TARGET_TAG=${TAG}', '.']
+          args: ['build', '-t', '${IMAGE}', '.']
         - name: '${TEST_RUNNER}'
 images:
         - '${IMAGE}'

--- a/builder/gen-dockerfile/src/create_dockerfile.php
+++ b/builder/gen-dockerfile/src/create_dockerfile.php
@@ -19,5 +19,10 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/GenFiles.php';
 
 $genFiles = new GenFiles();
-$genFiles->createDockerfile();
+if ($argc === 2) {
+    // Passing the base image
+    $genFiles->createDockerfile($argv[1]);
+} else {
+    $genFiles->createDockerfile();
+}
 $genFiles->createDockerignore();

--- a/builder/gen-dockerfile/src/templates/Dockerfile.twig
+++ b/builder/gen-dockerfile/src/templates/Dockerfile.twig
@@ -14,6 +14,6 @@
 
 # Dockerfile for App Engine Flexible environment for PHP
 
-FROM {{ base_image }}:{{ tag }}
+FROM {{ base_image }}
 
 ENV DOCUMENT_ROOT {{ document_root }}

--- a/builder/gen-dockerfile/tests/GenFilesTest.php
+++ b/builder/gen-dockerfile/tests/GenFilesTest.php
@@ -37,8 +37,6 @@ class GenFilesTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         // Set default envvar
-        putenv('BUILDER_TARGET_IMAGE=' . \GenFiles::DEFAULT_BASE_IMAGE);
-        putenv('BUILDER_TARGET_TAG=' . \GenFiles::DEFAULT_TAG);
         putenv('GAE_APPLICATION_YAML_PATH=app.yaml');
     }
 
@@ -97,12 +95,6 @@ class GenFilesTest extends \PHPUnit_Framework_TestCase
 
     public function dataProvider()
     {
-        $dir,
-        $baseImage,
-        $appYamlEnv,
-        $expectedDocRoot,
-        $expectedDockerIgnore,
-        $expectedFrom
         return [
             [
                 // Simplest case
@@ -125,7 +117,7 @@ class GenFilesTest extends \PHPUnit_Framework_TestCase
             [
                 // Overrides baseImage
                 __DIR__ . '/test_data/simplest',
-                'gcr.io/php-mvm-a/php-nginx:latest'
+                'gcr.io/php-mvm-a/php-nginx:latest',
                 '',
                 '/app',
                 'added by the php runtime builder',

--- a/builder/php-latest.yaml
+++ b/builder/php-latest.yaml
@@ -1,5 +1,7 @@
 steps:
   - name: 'gcr.io/gcp-runtimes/php/gen-dockerfile:latest'
+    args:
+    - 'gcr.io/google-appengine/php:latest'
   - name: 'gcr.io/cloud-builders/docker:latest'
     args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
 images:


### PR DESCRIPTION
The `latest` tag in the `name` and `args` will be substituted with the exact sha value when we publish the builder definition file for pinning the pipeline to the specific image.