### PR TITLE
Sending php-fpm's error log to /dev/stderr

### DIFF
--- a/php-nginx/php-fpm.conf
+++ b/php-nginx/php-fpm.conf
@@ -44,7 +44,7 @@ pid = /var/run/php-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /opt/php/var
 ; Default Value: log/php-fpm.log
-error_log = /dev/null
+error_log = /dev/stderr
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities


### PR DESCRIPTION
Now php-fpm throw away the output on stderr with the following configuration:
```
error_log = /dev/null
```

So the following code in php-fpm silently throws away the logs.
```
$stderr = fopen('php://stderr', 'w');
fwrite($stderr, 'Log to stderr' . PHP_EOL);
```