### PR TITLE
Fix package build script.

### DIFF
--- a/deb-package-builder/build_packages.sh
+++ b/deb-package-builder/build_packages.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
 
 if [ -z "${GOOGLE_PROJECT_ID}" ]; then
     echo "You need to set GOOGLE_PROJECT_ID envvar."
@@ -6,7 +21,7 @@ if [ -z "${GOOGLE_PROJECT_ID}" ]; then
 fi
 
 if [ -z "${PHP_VERSIONS}" ]; then
-    PHP_VERSIONS='7.1.4-1,7.0.18-1,5.6.30-2'
+    PHP_VERSIONS='7.1.4-2,7.0.18-2,5.6.30-3'
     echo "Defaulting PHP Versions to: ${PHP_VERSIONS}"
 fi
 
@@ -30,5 +45,5 @@ do
     echo "Building packages for PHP ${VERSION}"
     gcloud container builds submit . --config=build-packages.yaml \
                                      --substitutions _PHP_VERSION=${VERSION},_IMAGE=${IMAGE},_BUCKET=${BUCKET} \
-                                     --timeout=30m
+                                     --timeout=40m
 done


### PR DESCRIPTION
Add license.
If any steps fails, fail the build.
Increase the timeout for building all the extensions.
Fix the default versions of PHP that we're building.