### PR TITLE
Use envvar DOCUMENT_ROOT in nginx.conf

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -58,7 +58,7 @@ ENV NGINX_DIR=/etc/nginx \
     PHP71_VERSION=7.1.1 \
     PATH=/opt/php/bin:$PATH \
     WWW_HOME=/var/www \
-    DOCUMENT_ROOT=${APP_DIR} # default value
+    DOCUMENT_ROOT=${APP_DIR}
 
 # Install build scripts - composer, nginx, php
 COPY build-scripts /build-scripts

--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -57,7 +57,8 @@ ENV NGINX_DIR=/etc/nginx \
     PHP70_VERSION=7.0.15 \
     PHP71_VERSION=7.1.1 \
     PATH=/opt/php/bin:$PATH \
-    WWW_HOME=/var/www
+    WWW_HOME=/var/www \
+    DOCUMENT_ROOT=${APP_DIR} # default value
 
 # Install build scripts - composer, nginx, php
 COPY build-scripts /build-scripts

--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -58,7 +58,7 @@ ENV NGINX_DIR=/etc/nginx \
     PHP71_VERSION=7.1.1 \
     PATH=/opt/php/bin:$PATH \
     WWW_HOME=/var/www \
-    DOCUMENT_ROOT=${APP_DIR}
+    DOCUMENT_ROOT=/app
 
 # Install build scripts - composer, nginx, php
 COPY build-scripts /build-scripts

--- a/php-nginx/build-scripts/install_nginx.sh
+++ b/php-nginx/build-scripts/install_nginx.sh
@@ -18,4 +18,4 @@
 # A shell script for installing nginx.
 set -xe
 
-apt-get install -y nginx --no-install-recommends
+apt-get install -y nginx-extras --no-install-recommends

--- a/php-nginx/entrypoint.sh
+++ b/php-nginx/entrypoint.sh
@@ -99,15 +99,6 @@ session.save_path="${MEMCACHE_PORT_11211_TCP_ADDR}:${MEMCACHE_PORT_11211_TCP_POR
 EOF
 fi
 
-# Configure document root in php.ini and nginx.conf with DOCUMENT_ROOT
-# environment variable or APP_DIR if DOCUMENT_ROOT is not set.
-
-if [ -z "${DOCUMENT_ROOT}" ]; then
-    DOCUMENT_ROOT="${APP_DIR}"
-fi
-
-sed -i "s|%%DOC_ROOT%%|${DOCUMENT_ROOT}|g" "${NGINX_DIR}/nginx.conf"
-
 if [ -f "${APP_DIR}/composer.json" ]; then
     # run the composer scripts for post-deploy
     if su www-data -c "php /usr/local/bin/composer --no-ansi run-script -l" \

--- a/php-nginx/nginx.conf
+++ b/php-nginx/nginx.conf
@@ -14,6 +14,8 @@
 
 daemon off;
 
+env DOCUMENT_ROOT;
+
 user  www-data;
 worker_processes  auto;
 error_log /dev/stderr info;
@@ -47,8 +49,11 @@ http {
     }
 
     server {
+
+        set_by_lua $docroot 'return os.getenv("DOCUMENT_ROOT")';
+
         listen       8080;
-        root %%DOC_ROOT%%;
+        root $docroot;
         index index.php index.html index.htm;
 
         # Media: images, icons, video, audio, HTC


### PR DESCRIPTION
This is an attempt to stop replacing the document root in `entrypoint.sh`.