### PR TITLE
Add app.yaml to the dockerignore with the runtime builder

### DIFF
--- a/builder/gen-dockerfile/src/GenFilesCommand.php
+++ b/builder/gen-dockerfile/src/GenFilesCommand.php
@@ -145,7 +145,7 @@ class GenFilesCommand extends Command
     }
 
     /**
-     * Creates a .dockerignore if it doesn't exist in the workspace.
+     * Creates .dockerignore, or adds some lines to an existing one.
      */
     public function createDockerignore()
     {

--- a/builder/gen-dockerfile/src/templates/dockerignore.twig
+++ b/builder/gen-dockerfile/src/templates/dockerignore.twig
@@ -7,3 +7,4 @@ Dockerfile
 # Emacs backup files
 *~
 .\#*
+{{ app_yaml_path }}

--- a/builder/gen-dockerfile/tests/GenFilesCommandTest.php
+++ b/builder/gen-dockerfile/tests/GenFilesCommandTest.php
@@ -92,6 +92,9 @@ class GenFilesCommandTest extends \PHPUnit_Framework_TestCase
             $expectedDockerIgnore,
             $dockerignore
         );
+        if (!empty($appYamlEnv)) {
+            $this->assertContains($appYamlEnv, $dockerignore);
+        }
         foreach ($otherExpectations as $expectation) {
             $this->assertContains($expectation, $dockerfile);
         }
@@ -107,8 +110,8 @@ class GenFilesCommandTest extends \PHPUnit_Framework_TestCase
                 '',
                 '/app',
                 'added by the php runtime builder',
-                'gcr.io/google-appengine/php-base:latest'
-                ["GOOGLE_RUNTIME_RUN_COMPOSER_SCRIPT=true \\\n"]
+                'gcr.io/google-appengine/php-base:latest',
+                ["GOOGLE_RUNTIME_RUN_COMPOSER_SCRIPT=true \n"]
             ],
             [
                 // whitelist_functions


### PR DESCRIPTION
* We also need to respect users' .dockerignore
* Docker image itself doesn't need app.yaml