### PR TITLE
Use /opt/composer for $COMPOSER_HOME

### DIFF
--- a/php-base/Dockerfile
+++ b/php-base/Dockerfile
@@ -58,6 +58,7 @@ ENV NGINX_DIR=/etc/nginx \
     PHP71_VERSION=7.1.1 \
     PATH=/opt/php/bin:$PATH \
     WWW_HOME=/var/www \
+    COMPOSER_HOME=/opt/composer \
     DOCUMENT_ROOT=/app
 
 # Install build scripts - composer, nginx, php
@@ -81,11 +82,11 @@ EXPOSE 8080
 
 # Lock down the web directories
 RUN mkdir -p $APP_DIR $UPLOAD_DIR $SESSION_SAVE_PATH \
-        $NGINX_USER_CONF_DIR $WWW_HOME \
+        $NGINX_USER_CONF_DIR $WWW_HOME $COMPOSER_HOME \
     && chown -R www-data.www-data \
         $APP_DIR $UPLOAD_DIR $SESSION_SAVE_PATH \
-        $NGINX_USER_CONF_DIR $WWW_HOME \
-    && chmod 755 $UPLOAD_DIR $SESSION_SAVE_PATH \
+        $NGINX_USER_CONF_DIR $WWW_HOME $COMPOSER_HOME \
+    && chmod 755 $UPLOAD_DIR $SESSION_SAVE_PATH $COMPOSER_HOME \
     # For easy access to php with `su www-data -c $CMD`
     && ln -sf ${PHP_DIR}/bin/php /usr/bin/php
 

--- a/php-base/composer.sh
+++ b/php-base/composer.sh
@@ -58,7 +58,7 @@ EOF
     COMPOSER_GITHUB_OAUTH_TOKEN=${COMPOSER_GITHUB_OAUTH_TOKEN:-}
     if [[ -n "$COMPOSER_GITHUB_OAUTH_TOKEN" ]]; then
         if curl --fail --silent -H "Authorization: token $COMPOSER_GITHUB_OAUTH_TOKEN" https://api.github.com/rate_limit > /dev/null; then
-            su www-data -c "php /usr/local/bin/composer \
+            su -m www-data -c "php /usr/local/bin/composer \
               config -g github-oauth.github.com ${COMPOSER_GITHUB_OAUTH_TOKEN} &> /dev/null"
             # redirect outdated version warnings (Composer sends those to STDOUT instead of STDERR)
             echo 'Using $COMPOSER_GITHUB_OAUTH_TOKEN for GitHub OAuth.'


### PR DESCRIPTION
It is better to always use a directory which is outside of the webroot, guaranteed to be writable to `www-data` user.

Related: #251 and #263 