### PR TITLE
Explicitly set the project id for the cloudbuild pipeline

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   # test runner
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG', '.']
     dir: cloudbuild-test-runner
     waitFor: ['-']
     id: test-runner
@@ -14,181 +14,181 @@ steps:
 
   # php-base
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php-base:$_TAG', '--build-arg', 'RUNTIME_DISTRIBUTION=$_RUNTIME_DISTRIBUTION', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-base:$_TAG', '--build-arg', 'RUNTIME_DISTRIBUTION=$_RUNTIME_DISTRIBUTION', '.']
     dir: php-base
     waitFor: ['-']
     id: php-base
   - name: gcr.io/gcp-runtimes/structure_test
-    args: ['-i', 'gcr.io/$PROJECT_ID/php-base:$_TAG', '--config', '/workspace/php-base/php-base.yaml', '-v']
+    args: ['-i', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-base:$_TAG', '--config', '/workspace/php-base/php-base.yaml', '-v']
     waitFor: ['php-base']
 
   # php-onbuild
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php:$_TAG', '.']
     dir: php-onbuild
     waitFor: ['php-base']
     id: php-onbuild
   - name: gcr.io/gcp-runtimes/structure_test
-    args: ['-i', 'gcr.io/$PROJECT_ID/php:$_TAG', '--config', '/workspace/php-onbuild/php.yaml', '-v']
+    args: ['-i', 'gcr.io/${_GOOGLE_PROJECT_ID}/php:$_TAG', '--config', '/workspace/php-onbuild/php.yaml', '-v']
     waitFor: ['php-onbuild']
 
   # gen-dockerfile
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php/gen-dockerfile:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php/gen-dockerfile:$_TAG', '.']
     dir: builder/gen-dockerfile
     waitFor: ['php-onbuild']
     id: gen-dockerfile
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '-v', '/workspace/builder/gen-dockerfile:/workspace', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG']
+    args: ['run', '-v', '/workspace/builder/gen-dockerfile:/workspace', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG']
     waitFor: ['test-runner']
-  - name: gcr.io/$PROJECT_ID/php/gen-dockerfile:$_TAG
+  - name: gcr.io/${_GOOGLE_PROJECT_ID}/php/gen-dockerfile:$_TAG
     args: ['--workspace', '/workspace/testapps/builder_test']
     waitFor: ['gen-dockerfile']
     id: gen-dockerfile-run
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '-v', '/workspace/testapps/builder_test:/workspace', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG']
+    args: ['run', '-v', '/workspace/testapps/builder_test:/workspace', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG']
     waitFor: ['gen-dockerfile-run', 'test-runner']
 
   # php-default test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php-default:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-default:$_TAG', '.']
     dir: testapps/php_default
     waitFor: ['php-onbuild']
     id: php-default-build
   - name: gcr.io/gcp-runtimes/structure_test
-    args: ['-i', 'gcr.io/$PROJECT_ID/php-default:$_TAG', '--config', 'php_default.yaml', '-v']
+    args: ['-i', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-default:$_TAG', '--config', 'php_default.yaml', '-v']
     waitFor: ['php-default-build']
 
   # php56 test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php56:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56:$_TAG', '.']
     dir: testapps/php56
     waitFor: ['php-onbuild']
     id: php56-build
   - name: gcr.io/gcp-runtimes/structure_test
-    args: ['-i', 'gcr.io/$PROJECT_ID/php56:$_TAG', '--config', 'php56.yaml', '-v']
+    args: ['-i', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56:$_TAG', '--config', 'php56.yaml', '-v']
     waitFor: ['php56-build']
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '--name=php56', '-d', 'gcr.io/$PROJECT_ID/php56:$_TAG']
+    args: ['run', '--net=nw_$_TAG', '--name=php56', '-d', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56:$_TAG']
     waitFor: ['php56-build', 'test-network']
     id: php56-app
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '-v', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG', '/workspace/testapps/php56']
+    args: ['run', '--net=nw_$_TAG', '-v', '/workspace:/workspace', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG', '/workspace/testapps/php56']
     waitFor: ['php56-app', 'test-runner']
 
   # php56-custom test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php56-custom:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-custom:$_TAG', '.']
     dir: testapps/php56_custom
     waitFor: ['php-onbuild']
     id: php56-custom-build
   - name: gcr.io/gcp-runtimes/structure_test
-    args: ['-i', 'gcr.io/$PROJECT_ID/php56-custom:$_TAG', '--config', 'php56_custom.yaml', '-v']
+    args: ['-i', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-custom:$_TAG', '--config', 'php56_custom.yaml', '-v']
     waitFor: ['php56-custom-build']
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '--name=php56-custom', '-d', 'gcr.io/$PROJECT_ID/php56-custom:$_TAG']
+    args: ['run', '--net=nw_$_TAG', '--name=php56-custom', '-d', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-custom:$_TAG']
     waitFor: ['php56-custom-build', 'test-network']
     id: php56-custom-app
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG','-v', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG', '/workspace/testapps/php56_custom']
+    args: ['run', '--net=nw_$_TAG','-v', '/workspace:/workspace', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG', '/workspace/testapps/php56_custom']
     waitFor: ['php56-custom-app', 'test-runner']
 
   # php56-custom-configs test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php56-custom-configs:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-custom-configs:$_TAG', '.']
     dir: testapps/php56_custom_configs
     waitFor: ['php-onbuild']
     id: php56-custom-configs-build
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '--name=php56-custom-configs', '-d', 'gcr.io/$PROJECT_ID/php56-custom-configs:$_TAG']
+    args: ['run', '--net=nw_$_TAG', '--name=php56-custom-configs', '-d', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-custom-configs:$_TAG']
     waitFor: ['php56-custom-configs-build', 'test-network']
     id: php56-custom-configs-app
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '-v', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG', '/workspace/testapps/php56_custom_configs']
+    args: ['run', '--net=nw_$_TAG', '-v', '/workspace:/workspace', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG', '/workspace/testapps/php56_custom_configs']
     waitFor: ['php56-custom-configs-app', 'test-runner']
 
   # php56-extensions test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php56-extensions:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-extensions:$_TAG', '.']
     dir: testapps/php56_extensions
     waitFor: ['php-onbuild']
     id: php56-extensions-build
   - name: gcr.io/cloud-builders/docker
-    args: ['run', 'gcr.io/$PROJECT_ID/php56-extensions:$_TAG', 'vendor/bin/phpunit']
+    args: ['run', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-extensions:$_TAG', 'vendor/bin/phpunit']
     dir: testapps/php56_extensions
     waitFor: ['php56-extensions-build']
 
   # php56-nginx-conf test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php56-nginx-conf:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-nginx-conf:$_TAG', '.']
     dir: testapps/php56_nginx_conf
     waitFor: ['php-onbuild']
     id: php56-nginx-conf-build
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '--name=php56-nginx-conf', '-d', 'gcr.io/$PROJECT_ID/php56-nginx-conf:$_TAG']
+    args: ['run', '--net=nw_$_TAG', '--name=php56-nginx-conf', '-d', 'gcr.io/${_GOOGLE_PROJECT_ID}/php56-nginx-conf:$_TAG']
     waitFor: ['php56-nginx-conf-build', 'test-network']
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '-v', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG', '/workspace/testapps/php56_nginx_conf']
+    args: ['run', '--net=nw_$_TAG', '-v', '/workspace:/workspace', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG', '/workspace/testapps/php56_nginx_conf']
     waitFor: ['php56-nginx-conf-build', 'test-runner']
 
   # php70-custom test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php70-custom:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php70-custom:$_TAG', '.']
     dir: testapps/php70_custom
     waitFor: ['php-onbuild']
     id: php70-custom-build
   - name: gcr.io/gcp-runtimes/structure_test
-    args: ['-i', 'gcr.io/$PROJECT_ID/php70-custom:$_TAG', '--config', 'php70.yaml', '-v']
+    args: ['-i', 'gcr.io/${_GOOGLE_PROJECT_ID}/php70-custom:$_TAG', '--config', 'php70.yaml', '-v']
     waitFor: ['php70-custom-build']
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '--name=php70-custom', '-d', 'gcr.io/$PROJECT_ID/php70-custom:$_TAG']
+    args: ['run', '--net=nw_$_TAG', '--name=php70-custom', '-d', 'gcr.io/${_GOOGLE_PROJECT_ID}/php70-custom:$_TAG']
     waitFor: ['php70-custom-build', 'test-network']
     id: php70-custom-app
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG','-v', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG', '/workspace/testapps/php70_custom/tests']
+    args: ['run', '--net=nw_$_TAG','-v', '/workspace:/workspace', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG', '/workspace/testapps/php70_custom/tests']
     waitFor: ['php70-custom-app', 'test-runner']
 
   # php70-extensions test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php70-extensions:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php70-extensions:$_TAG', '.']
     dir: testapps/php70_extensions
     waitFor: ['php-onbuild']
     id: php70-extensions-build
   - name: gcr.io/cloud-builders/docker
-    args: ['run', 'gcr.io/$PROJECT_ID/php70-extensions:$_TAG', 'vendor/bin/phpunit']
+    args: ['run', 'gcr.io/${_GOOGLE_PROJECT_ID}/php70-extensions:$_TAG', 'vendor/bin/phpunit']
     dir: testapps/php70_extensions
     waitFor: ['php70-extensions-build']
 
   # php71-custom test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php71-custom:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php71-custom:$_TAG', '.']
     dir: testapps/php71_custom
     waitFor: ['php-onbuild']
     id: php71-custom-build
   - name: gcr.io/gcp-runtimes/structure_test
-    args: ['-i', 'gcr.io/$PROJECT_ID/php71-custom:$_TAG', '--config', 'php71.yaml', '-v']
+    args: ['-i', 'gcr.io/${_GOOGLE_PROJECT_ID}/php71-custom:$_TAG', '--config', 'php71.yaml', '-v']
     waitFor: ['php71-custom-build']
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG', '--name=php71-custom', '-d', 'gcr.io/$PROJECT_ID/php71-custom:$_TAG']
+    args: ['run', '--net=nw_$_TAG', '--name=php71-custom', '-d', 'gcr.io/${_GOOGLE_PROJECT_ID}/php71-custom:$_TAG']
     waitFor: ['php71-custom-build', 'test-network']
     id: php71-custom-app
   - name: gcr.io/cloud-builders/docker
-    args: ['run', '--net=nw_$_TAG','-v', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG', '/workspace/testapps/php71_custom/tests']
+    args: ['run', '--net=nw_$_TAG','-v', '/workspace:/workspace', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG', '/workspace/testapps/php71_custom/tests']
     waitFor: ['php71-custom-app', 'test-runner']
 
   # php71-extensions test
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php71-extensions:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php71-extensions:$_TAG', '.']
     dir: testapps/php71_extensions
     waitFor: ['php-onbuild']
     id: php71-extensions-build
   - name: gcr.io/cloud-builders/docker
-    args: ['run', 'gcr.io/$PROJECT_ID/php71-extensions:$_TAG', 'vendor/bin/phpunit']
+    args: ['run', 'gcr.io/${_GOOGLE_PROJECT_ID}/php71-extensions:$_TAG', 'vendor/bin/phpunit']
     dir: testapps/php71_extensions
     waitFor: ['php71-extensions-build']
 
 images:
-  - gcr.io/$PROJECT_ID/php-base:$_TAG
-  - gcr.io/$PROJECT_ID/php:$_TAG
-  - gcr.io/$PROJECT_ID/php/gen-dockerfile:$_TAG
-  - gcr.io/$PROJECT_ID/php-test-runner:$_TAG
+  - gcr.io/${_GOOGLE_PROJECT_ID}/php-base:$_TAG
+  - gcr.io/${_GOOGLE_PROJECT_ID}/php:$_TAG
+  - gcr.io/${_GOOGLE_PROJECT_ID}/php/gen-dockerfile:$_TAG
+  - gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG

--- a/integration-tests.yaml
+++ b/integration-tests.yaml
@@ -1,28 +1,28 @@
 steps:
   # test runner
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/php-test-runner:$_TAG', '.']
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG', '.']
     dir: cloudbuild-test-runner
     waitFor: ['-']
     id: test-runner
 
   # php71_e2e test
-  - name: gcr.io/$PROJECT_ID/php-test-runner:$_TAG
+  - name: gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG
     args: ['/workspace/testapps/php71_e2e/tests']
     waitFor: ['test-runner']
     id: php71_e2e
     env:
     - 'SERVICE_ACCOUNT_JSON=${_SERVICE_ACCOUNT_JSON}'
     - 'TAG=${_TAG}-e2e'
-    - 'GOOGLE_PROJECT_ID=${_E2E_PROJECT_ID}'
+    - 'E2E_PROJECT_ID=${_E2E_PROJECT_ID}'
 
   # build_pipeline test
-  - name: gcr.io/$PROJECT_ID/php-test-runner:$_TAG
+  - name: gcr.io/${_GOOGLE_PROJECT_ID}/php-test-runner:$_TAG
     args: ['/workspace/testapps/build_pipeline/tests']
     waitFor: ['test-runner']
     id: build_pipeline
     env:
     - 'SERVICE_ACCOUNT_JSON=${_SERVICE_ACCOUNT_JSON}'
     - 'TAG=${_TAG}-build-pipeline'
-    - 'GOOGLE_PROJECT_ID=${_E2E_PROJECT_ID}'
+    - 'E2E_PROJECT_ID=${_E2E_PROJECT_ID}'
     - 'RUNTIME_BUILDER_ROOT=${_RUNTIME_BUILDER_ROOT}'

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -41,7 +41,7 @@ done
 gcloud container builds submit . \
   --config cloudbuild.yaml \
   --timeout 3600 \
-  --substitutions _TAG=$TAG,_RUNTIME_DISTRIBUTION=$RUNTIME_DISTRIBUTION
+  --substitutions _GOOGLE_PROJECT_ID=$GOOGLE_PROJECT_ID,_TAG=$TAG,_RUNTIME_DISTRIBUTION=$RUNTIME_DISTRIBUTION
 
 # if running on circle for the master branch, run the e2e tests
 if [ "${CIRCLE_BRANCH}" = "master" ]
@@ -60,8 +60,8 @@ else
     fi
 
     # replace runtime builder pipeline :latest with our newly tagged images
-    sed -e 's/google-appengine/$PROJECT_ID/g' \
-        -e 's/gcp-runtimes/$PROJECT_ID/g' \
+    sed -e "s/google-appengine/${GOOGLE_PROJECT_ID}/g" \
+        -e "s/gcp-runtimes/${GOOGLE_PROJECT_ID}/g" \
         -e "/docker:latest/!s/:latest/:${TAG}/g" builder/php-latest.yaml > builder/php-test.yaml
 
     echo "Using test build pipeline:"
@@ -70,5 +70,5 @@ else
     gcloud container builds submit . \
       --config integration-tests.yaml \
       --timeout 3600 \
-      --substitutions _TAG=$TAG,_SERVICE_ACCOUNT_JSON=$SERVICE_ACCOUNT_JSON,_E2E_PROJECT_ID=$E2E_PROJECT_ID,_RUNTIME_BUILDER_ROOT=file:///workspace/builder/
+      --substitutions _GOOGLE_PROJECT_ID=$GOOGLE_PROJECT_ID,_TAG=$TAG,_SERVICE_ACCOUNT_JSON=$SERVICE_ACCOUNT_JSON,_E2E_PROJECT_ID=$E2E_PROJECT_ID,_RUNTIME_BUILDER_ROOT=file:///workspace/builder/
 fi

--- a/scripts/run_acceptance_tests.sh
+++ b/scripts/run_acceptance_tests.sh
@@ -39,7 +39,13 @@ do
   envsubst '${BASE_IMAGE} ${PHP_BASE_IMAGE}' < ${TEMPLATE} > $(dirname ${TEMPLATE})/$(basename -s .in ${TEMPLATE})
 done
 
+if [ -z "${E2E_PROJECT_ID}" ]
+then
+    echo "Defaulting E2E_PROJECT_ID to GOOGLE_PROJECT_ID"
+    E2E_PROJECT_ID=$GOOGLE_PROJECT_ID
+fi
+
 gcloud container builds submit . \
   --config integration-tests.yaml \
   --timeout 3600 \
-  --substitutions _TAG=$TAG,_SERVICE_ACCOUNT_JSON=$SERVICE_ACCOUNT_JSON,_E2E_PROJECT_ID=$GOOGLE_PROJECT_ID,_RUNTIME_BUILDER_ROOT=
+  --substitutions _GOOGLE_PROJECT_ID=$GOOGLE_PROJECT_ID,_TAG=$TAG,_SERVICE_ACCOUNT_JSON=$SERVICE_ACCOUNT_JSON,_E2E_PROJECT_ID=$E2E_PROJECT_ID,_RUNTIME_BUILDER_ROOT=

--- a/testapps/build_pipeline/tests/tests/EndToEndTest.php
+++ b/testapps/build_pipeline/tests/tests/EndToEndTest.php
@@ -27,7 +27,7 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
 
     private $client;
 
-    const PROJECT_ENV = 'GOOGLE_PROJECT_ID';
+    const PROJECT_ENV = 'E2E_PROJECT_ID';
     const VERSION_ENV = 'TAG';
     const SERVICE_ACCOUNT_ENV = 'SERVICE_ACCOUNT_JSON';
     const RUNTIME_BUILDER_ROOT_ENV = 'RUNTIME_BUILDER_ROOT';
@@ -88,11 +88,14 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
 
     public static function deploy($project_id, $e2e_test_version)
     {
+        $command = "gcloud -q beta app deploy --version $e2e_test_version"
+            . " --project $project_id --no-promote"
+            . ' ../app.yaml';
+        printf("Executing command: '%s'\n", $command);
+
         for ($i = 0; $i <= 3; $i++) {
             exec(
-                "gcloud -q beta app deploy --version $e2e_test_version"
-                . " --project $project_id --no-promote"
-                . ' ../app.yaml',
+                $command,
                 $output,
                 $ret
             );

--- a/testapps/php71_e2e/tests/tests/EndToEndTest.php
+++ b/testapps/php71_e2e/tests/tests/EndToEndTest.php
@@ -27,7 +27,7 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
 
     private $client;
 
-    const PROJECT_ENV = 'GOOGLE_PROJECT_ID';
+    const PROJECT_ENV = 'E2E_PROJECT_ID';
     const VERSION_ENV = 'TAG';
     const SERVICE_ACCOUNT_ENV = 'SERVICE_ACCOUNT_JSON';
 
@@ -70,11 +70,13 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
 
     public static function deploy($project_id, $e2e_test_version)
     {
+        $command = "gcloud -q app deploy --version $e2e_test_version"
+            . " --project $project_id --no-promote"
+            . ' ../app.yaml';
+        printf("Executing command: '%s'\n", $command);
         for ($i = 0; $i <= 3; $i++) {
             exec(
-                "gcloud -q app deploy --version $e2e_test_version"
-                . " --project $project_id --no-promote"
-                . ' ../app.yaml',
+                $command,
                 $output,
                 $ret
             );


### PR DESCRIPTION
Instead of implicitly relying on the currently configured project id, use the provided environment variable.

`$GOOGLE_PROJECT_ID` is the project where the images are built, `$E2E_PROJECT_ID` is where the project is deployed to for E2E tests.

In the E2E tests, we will set the current project id to the `E2E_PROJECT_ID`. The provided service account from the `SERVICE_ACCOUNT_JSON` should have enough permissions to deploy an App Engine application to the `E2E_PROJECT_ID`

Also changed the environment variable we look for in the E2E tests to `E2E_PROJECT_ID` to ease confusion.