### PR TITLE
Allow acceptance test to use default pipeline

### DIFF
--- a/testapps/build_pipeline/tests/tests/EndToEndTest.php
+++ b/testapps/build_pipeline/tests/tests/EndToEndTest.php
@@ -47,7 +47,7 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
         if ($service_account_json == false) {
             self::fail('Please set ' . self::SERVICE_ACCOUNT_ENV . ' env var.');
         }
-        if ($runtime_builder_root == false) {
+        if ($runtime_builder_root === false) {
             self::fail('Please set ' . self::RUNTIME_BUILDER_ROOT_ENV . ' env var.');
         }
 


### PR DESCRIPTION
by allowing RUNTIME_BUILDER_ROOT env to be an empty string.

In PHP: 

```php
var_dump("" == false);
=> bool(true)

var_dump("" === false);
=> bool(false)
```