### PR TITLE
Build the test-runner from the latest prod image for acceptance tests

### DIFF
--- a/scripts/run_acceptance_tests.sh
+++ b/scripts/run_acceptance_tests.sh
@@ -33,12 +33,11 @@ fi
 
 export PHP_BASE_IMAGE="gcr.io/google-appengine/php-base"
 export BASE_IMAGE="gcr.io/google-appengine/php"
-export PHP_56_IMAGE="gcr.io/${GOOGLE_PROJECT_ID}/php56:${TAG}"
-export PHP_71_IMAGE="gcr.io/${GOOGLE_PROJECT_ID}/php71:${TAG}"
+export PHP_56_IMAGE="gcr.io/google-appengine/php56"
 
 for TEMPLATE in `find . -name Dockerfile.in`
 do
-    envsubst '${BASE_IMAGE} ${PHP_BASE_IMAGE} ${PHP_71_IMAGE} ${PHP_56_IMAGE}' \
+    envsubst '${BASE_IMAGE} ${PHP_BASE_IMAGE} ${PHP_56_IMAGE}' \
              < ${TEMPLATE} \
              > $(dirname ${TEMPLATE})/$(basename -s .in ${TEMPLATE})
 done


### PR DESCRIPTION
Sorry it succeeded on my workstation with the same TAG, but fails with timestamped TAG on our jenkins.