### PR TITLE
Build the debian package builder image as part of the cloudbuild.

### DIFF
--- a/deb-package-builder/build-packages.yaml
+++ b/deb-package-builder/build-packages.yaml
@@ -1,7 +1,9 @@
 steps:
+  - name: gcr.io/cloud-builders/docker
+    args: ['build', '-t', 'gcr.io/${_GOOGLE_PROJECT_ID}/deb-package-builder', '.']
   - name: gcr.io/cloud-builders/gsutil
     args: ['-m', 'rsync', 'gs://${_BUCKET}/packages/${_PHP_VERSION}/', '/workspace/pkg/']
-  - name: ${_IMAGE}
+  - name: gcr.io/${_GOOGLE_PROJECT_ID}/deb-package-builder
     args: ['${_PHP_VERSION}']
   - name: gcr.io/cloud-builders/gsutil
     args: ['-m', 'rsync', '/workspace/pkg/', 'gs://${_BUCKET}/packages/${_PHP_VERSION}/']

--- a/deb-package-builder/build_packages.sh
+++ b/deb-package-builder/build_packages.sh
@@ -30,20 +30,11 @@ if [ -z "${BUCKET}" ]; then
     echo "Defaulting Bucket to: ${BUCKET}"
 fi
 
-IMAGE="gcr.io/${GOOGLE_PROJECT_ID}/deb-package-builder"
-
-# First, build the package builder
-if [ -z "${USE_LATEST}" ]; then
-    echo "Building package builder..."
-    gcloud container builds submit . --config=builder.yaml \
-                                     --substitutions _IMAGE=${IMAGE}
-fi
-
 # Use the package builder
 for VERSION in $(echo ${PHP_VERSIONS} | tr "," "\n")
 do
     echo "Building packages for PHP ${VERSION}"
     gcloud container builds submit . --config=build-packages.yaml \
-                                     --substitutions _PHP_VERSION=${VERSION},_IMAGE=${IMAGE},_BUCKET=${BUCKET} \
+                                     --substitutions _PHP_VERSION=${VERSION},_GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID},_BUCKET=${BUCKET} \
                                      --timeout=40m
 done

--- a/deb-package-builder/builder.yaml
+++ b/deb-package-builder/builder.yaml
@@ -1,6 +1,0 @@
-steps:
-  - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', '${_IMAGE}', '.']
-
-images:
-  - ${_IMAGE}


### PR DESCRIPTION
Skip tagging the builder image as it's not needed by anything else
except this pipeline.