### PR TITLE
update the debian sub-version for the php base packages (including gmp)

### DIFF
--- a/deb-package-builder/build_packages.sh
+++ b/deb-package-builder/build_packages.sh
@@ -21,7 +21,7 @@ if [ -z "${GOOGLE_PROJECT_ID}" ]; then
 fi
 
 if [ -z "${PHP_VERSIONS}" ]; then
-    PHP_VERSIONS='7.1.5-1,7.0.19-1,5.6.30-3'
+    PHP_VERSIONS='7.1.5-2,7.0.19-2,5.6.30-4'
     echo "Defaulting PHP Versions to: ${PHP_VERSIONS}"
 fi
 


### PR DESCRIPTION
Updating the default here rather than setting the environment variables for every build environment when building new versions.