### PR TITLE
change runtime to custom in integration sample app

### DIFF
--- a/testapps/integration/app.yaml
+++ b/testapps/integration/app.yaml
@@ -1,4 +1,4 @@
-runtime: php
+runtime: custom
 env: flex
 
 runtime_config:


### PR DESCRIPTION
since we're substituting in a newly built staging base runtime image, we need to use the custom runtime to deploy this app.

@tmatsuo 