### PR TITLE
[WIP] First trial for upgrading to debian 9 (Stretch)

### DIFF
--- a/deb-package-builder/Dockerfile
+++ b/deb-package-builder/Dockerfile
@@ -18,14 +18,18 @@
 # Then you'll get deb packages in /mydir.
 
 # Inherit the php base image so we use the same dependency libraries
-FROM gcr.io/google-appengine/php
+FROM gcr.io/google-appengine/debian9
+
+ENV PATH=${PATH}:/opt/php/bin \
+  PHP_DIR=/opt/php
 
 # Need to install debian packaging tools etc
-RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list && \
-    apt-get update -y && \
+RUN apt-get update -y && \
     apt-get install -y -q --no-install-recommends \
+        curl \
         debhelper \
         devscripts \
+        gnupg \
         libparse-debcontrol-perl \
         # headers
         libbz2-dev \
@@ -33,7 +37,7 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sou
         libfreetype6-dev \
         libgettextpo-dev \
         libgmp-dev \
-        libuv1-dev/jessie-backports \
+        libuv1-dev \
         libicu-dev \
         libjpeg62-turbo-dev \
         libjson-c-dev \
@@ -46,6 +50,7 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sou
         libreadline6-dev \
         librecode-dev \
         libsasl2-dev \
+        libsasl2-modules \
         libsqlite3-dev \
         libssl-dev \
         libxml2-dev \
@@ -73,5 +78,7 @@ RUN echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sou
 COPY build.sh /
 RUN mkdir -p /workspace
 WORKDIR /workspace
+
+# COPY . /workspace
 
 ENTRYPOINT ["/build.sh"]

--- a/deb-package-builder/build.sh
+++ b/deb-package-builder/build.sh
@@ -40,7 +40,7 @@ PHP_VERSIONS=${1}
 EXTENSIONS=${2}
 if [ -z "$EXTENSIONS" ]; then
     # Explicitly declaring because some extenions depend on others (pq depends on raphf)
-    EXTENSIONS="apcu,apcu_bc,ev,event,grpc,imagick,jsonc,mailparse,memcache,memcached,mongodb,oauth,phalcon,protobuf,raphf,pq,rdkafka,redis,suhosin,libuv,cassandra-cpp-driver,cassandra"
+    EXTENSIONS="apcu,apcu_bc,ev,event,grpc,imagick,jsonc,mailparse,memcache,memcached,mongodb,oauth,phalcon,protobuf,raphf,pq,rdkafka,redis,suhosin"
 fi
 
 

--- a/deb-package-builder/build_packages.sh
+++ b/deb-package-builder/build_packages.sh
@@ -21,7 +21,7 @@ if [ -z "${GOOGLE_PROJECT_ID}" ]; then
 fi
 
 if [ -z "${PHP_VERSIONS}" ]; then
-    PHP_VERSIONS='7.1.7-1,7.0.21-1,5.6.30-4,7.2.0alpha3-1'
+    PHP_VERSIONS='7.1.7-1,7.0.21-1,5.6.31-1,7.2.0alpha3-1'
     echo "Defaulting PHP Versions to: ${PHP_VERSIONS}"
 fi
 

--- a/deb-package-builder/debian/control.in
+++ b/deb-package-builder/debian/control.in
@@ -2,11 +2,11 @@ Source: gcp-php${SHORT_VERSION}
 Section: unknown
 Priority: optional
 Maintainer: Takashi Matsuo <tmatsuo@google.com>
-Build-Depends: debhelper (>= 8.0.0), devscripts, build-essential, libparse-debcontrol-perl, libbz2-dev, libcurl4-openssl-dev, libgettextpo-dev, libicu-dev, libjpeg62-turbo-dev, libmcrypt-dev, libmemcached-dev, libpcre3-dev, libpng-dev, libpq-dev, libreadline6-dev, librecode-dev, libsasl2-dev, libsqlite3-dev, libssl-dev, libxml2-dev, libxslt1-dev, zlib1g-dev, libfreetype6-dev
+Build-Depends: debhelper (>= 8.0.0), devscripts, build-essential, libparse-debcontrol-perl, libbz2-dev, libcurl4-openssl-dev, libgettextpo-dev, libicu-dev, libjpeg62-turbo-dev, libmcrypt-dev, libmemcached-dev, libpcre3-dev, libpng-dev, libpq-dev, libreadline-dev, librecode-dev, libsasl2-dev, libsqlite3-dev, libssl-dev, libxml2-dev, libxslt1-dev, zlib1g-dev, libfreetype6-dev
 Standards-Version: 3.9.4
 Homepage: http://php.net/
 
 Package: gcp-php${SHORT_VERSION}
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, gettext, libbz2-1.0, libfreetype6, libicu52, libjpeg62-turbo, libmcrypt4, libmemcached11, libmemcachedutil2, libpcre3, libpng12-0, libpq5, libreadline6, librecode0, libsasl2-modules, libsqlite3-0, libxml2, libxslt1.1, openssl, zlib1g
+Depends: ${shlibs:Depends}, ${misc:Depends}, gettext, libbz2-1.0, libfreetype6, libicu57, libjpeg62-turbo, libmcrypt4, libmemcached11, libmemcachedutil2, libpcre3, libpng16-16, libpq5, libreadline7, librecode0, libsasl2-modules, libsqlite3-0, libxml2, libxslt1.1, openssl, zlib1g
 Description: PHP for Google Cloud Platform runtimes

--- a/deb-package-builder/debian/rules.in
+++ b/deb-package-builder/debian/rules.in
@@ -10,7 +10,8 @@
 override_dh_auto_configure:
 	rm -f configure \
 	&& ./buildconf --force \
-	&& ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h \
+	&& ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h \
+	&& ln -sf /usr/include/x86_64-linux-gnu/curl /usr/include/curl \
 	&& dh_auto_configure -- --prefix=/opt/php${SHORT_VERSION} \
 	--with-config-file-path=/opt/php${SHORT_VERSION}/lib \
 	--with-config-file-scan-dir=/opt/php${SHORT_VERSION}/lib/ext.enabled:/opt/php${SHORT_VERSION}/lib/conf.d:/app \

--- a/php-base/Dockerfile
+++ b/php-base/Dockerfile
@@ -14,7 +14,7 @@
 
 # Dockerfile for PHP 5.6/7.0 using nginx as the webserver.
 
-FROM gcr.io/google_appengine/debian8
+FROM gcr.io/google_appengine/debian9
 
 RUN apt-get update -y && \
     apt-get -y upgrade && \
@@ -22,16 +22,17 @@ RUN apt-get update -y && \
     curl \
     gettext \
     git \
+    gnupg \
     libbz2-1.0 \
-    libicu52 \
+    libicu57 \
     libjpeg62-turbo \
     libmcrypt4 \
     libmemcached11 \
     libmemcachedutil2 \
     libpcre3 \
-    libpng12-0 \
+    libpng16-16 \
     libpq5 \
-    libreadline6 \
+    libreadline7 \
     librecode0 \
     libsasl2-modules \
     libsqlite3-0 \


### PR DESCRIPTION
Mainly for the record

Stretch has openssl 1.1 and some packages have an issue compiling against it.

Related issues:
- cassandra-cpp-driver: https://datastax-oss.atlassian.net/browse/CPP-438
- php 5.6: https://github.com/oerdnj/deb.sury.org/issues/566
- curl header: https://github.com/phpbrew/phpbrew/issues/861