### PR TITLE
Fixed a wrong command for setting app/use_runtime_builders config

### DIFF
--- a/perf-dashboard/deployment-latency/cloudbuild.yaml
+++ b/perf-dashboard/deployment-latency/cloudbuild.yaml
@@ -2,3 +2,4 @@ steps:
     - name: ${_TEST_RUNNER}
       env:
       - GCLOUD_TRACK=${_GCLOUD_TRACK}
+      - GOOGLE_PROJECT_ID=${_GOOGLE_PROJECT_ID}

--- a/perf-dashboard/deployment-latency/tests/CollectDeploymentLatencyTest.php
+++ b/perf-dashboard/deployment-latency/tests/CollectDeploymentLatencyTest.php
@@ -22,7 +22,6 @@ use Google\Cloud\BigQuery\BigQueryClient;
 class CollectDeploymentLatencyTest extends \PHPUnit_Framework_TestCase
 {
     const DEPLOYMENT_MAX_RETRY = 5;
-    const PROJECT_ID = 'php-perf-dash';
     const DATASET_ID = 'deployment_latency';
     const TABLE_ID = 'flex_deployments';
 
@@ -121,7 +120,7 @@ class CollectDeploymentLatencyTest extends \PHPUnit_Framework_TestCase
 
         return new BigQueryClient(
             [
-                'projectId' => self::PROJECT_ID,
+                'projectId' => getenv('GOOGLE_PROJECT_ID'),
                 'accessToken' => $token['access_token']
             ]
         );

--- a/perf-dashboard/deployment-latency/tests/CollectDeploymentLatencyTest.php
+++ b/perf-dashboard/deployment-latency/tests/CollectDeploymentLatencyTest.php
@@ -76,7 +76,7 @@ class CollectDeploymentLatencyTest extends \PHPUnit_Framework_TestCase
                     . str_replace('.', '', $reportName)
                     . ' --no-stop-previous-version --no-promote';
                 $configCmd = 'gcloud config set app/use_runtime_builders '
-                    . $type === 'xrt' ? 'false' : 'true';
+                    . ($type === 'xrt' ? 'false' : 'true');
                 self::execWithError($configCmd, 'runtime-builders-config');
                 $latency = 0.0;
                 while ($failureCount < self::DEPLOYMENT_MAX_RETRY) {

--- a/scripts/record_deployment_latency.sh
+++ b/scripts/record_deployment_latency.sh
@@ -43,4 +43,4 @@ fi
 gcloud -q container builds submit perf-dashboard/deployment-latency\
        --timeout 7200 \
        --config perf-dashboard/deployment-latency/cloudbuild.yaml \
-       --substitutions _TEST_RUNNER="${TEST_RUNNER}",_GCLOUD_TRACK="${GCLOUD_TRACK}"
+       --substitutions _TEST_RUNNER="${TEST_RUNNER}",_GCLOUD_TRACK="${GCLOUD_TRACK}",_GOOGLE_PROJECT_ID=${GOOGLE_PROJECT_ID}


### PR DESCRIPTION
Sorry, I noticed that it was always using xrt (it ran the command `false` and `true` instead).

With this change, it correctly uses the runtime builder.