### PR TITLE
Adding automatic setup for stackdriver integration

### DIFF
--- a/builder/gen-dockerfile/src/Builder/Exception/GoogleCloudVersionException.php
+++ b/builder/gen-dockerfile/src/Builder/Exception/GoogleCloudVersionException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Runtimes\Builder\Exception;
+
+class GoogleCloudVersionException extends \RuntimeException
+{
+}

--- a/builder/gen-dockerfile/src/ValidateGoogleCloud.php
+++ b/builder/gen-dockerfile/src/ValidateGoogleCloud.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Runtimes;
+
+use Composer\Semver\Semver;
+use Composer\Semver\Comparator;
+use Google\Cloud\Runtimes\Builder\Exception\GoogleCloudVersionException;
+
+class ValidateGoogleCloud
+{
+    const MINIMUM_VERSION = 'v0.33';
+
+    /*
+     * @param string $workspace
+     * @return bool
+     * @throw GoogleCloudVersionException
+     */
+    public static function doCheck($workspace)
+    {
+        $filename = $workspace . '/composer.json';
+        if (! file_exists($filename)) {
+            throw new GoogleCloudVersionException(
+                'composer.json does not exist'
+            );
+        }
+        $composer = json_decode(file_get_contents($filename), true);
+        if (is_array($composer)
+            && array_key_exists('require', $composer)
+            && array_key_exists('google/cloud', $composer['require'])) {
+            $constraints = $composer['require']['google/cloud'];
+        } else {
+            throw new GoogleCloudVersionException(
+                'google/cloud not found in composer.json'
+            );
+        }
+
+        $versions = self::getCurrentGoogleCloudVersions();
+
+        // Check all the available versions against the constraints
+        // and returns matched ones
+        $filtered = Semver::satisfiedBy($versions, $constraints);
+
+        if (count($filtered) === 0) {
+            throw new GoogleCloudVersionException(
+                'no available matching version of google/cloud'
+            );
+        }
+        foreach ($filtered as $version) {
+            if (Comparator::lessThan($version, self::MINIMUM_VERSION)) {
+                throw new GoogleCloudVersionException(
+                    'stackdriver integration needs google/cloud '
+                    . self::MINIMUM_VERSION . ' or higher'
+                );
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Determine available versions for google/cloud
+     * @return array
+     */
+    private static function getCurrentGoogleCloudVersions()
+    {
+        exec(
+            'composer show --all google/cloud |grep \'versions : \'',
+            $output,
+            $ret
+        );
+        if ($ret !== 0) {
+            throw new GoogleCloudVersionException(
+                'Failed to determine available versions of google/cloud package'
+            );
+        }
+        // Remove the title
+        $output = substr($output[0], strlen('versions : '));
+
+        // Split the version strings
+        $versions = preg_split('/[,\s]+/', $output);
+
+        // Remove '*', indicator for the latest stable
+        $versions = array_diff($versions, ['*']);
+        return $versions;
+    }
+}

--- a/builder/gen-dockerfile/tests/GenFilesCommandTest.php
+++ b/builder/gen-dockerfile/tests/GenFilesCommandTest.php
@@ -140,6 +140,54 @@ class GenFilesCommandTest extends \PHPUnit_Framework_TestCase
                 ]
             ],
             [
+                // stackdriver simple case
+                __DIR__ . '/test_data/stackdriver_simple',
+                null,
+                '',
+                '/app/web',
+                'added by the php runtime builder',
+                'gcr.io/google-appengine/php71:latest',
+                ["GOOGLE_RUNTIME_RUN_COMPOSER_SCRIPT=true \\\n",
+                 "FRONT_CONTROLLER_FILE=index.php \\\n",
+                 "DETECTED_PHP_VERSION=7.1 \\\n",
+                 "IS_BATCH_DAEMON_RUNNING=true \n",
+                 "enable_stackdriver_integration.sh"
+                ]
+            ],
+            [
+                // stackdriver no composer.json
+                __DIR__ . '/test_data/stackdriver_no_composer',
+                null,
+                '',
+                '/app/web',
+                'added by the php runtime builder',
+                'gcr.io/google-appengine/php71:latest',
+                [],
+                '\\Google\\Cloud\\Runtimes\\Builder\\Exception\\GoogleCloudVersionException'
+            ],
+            [
+                // stackdriver no google/cloud
+                __DIR__ . '/test_data/stackdriver_no_google_cloud',
+                null,
+                '',
+                '/app/web',
+                'added by the php runtime builder',
+                'gcr.io/google-appengine/php71:latest',
+                [],
+                '\\Google\\Cloud\\Runtimes\\Builder\\Exception\\GoogleCloudVersionException'
+            ],
+            [
+                // stackdriver old google/cloud
+                __DIR__ . '/test_data/stackdriver_old_google_cloud',
+                null,
+                '',
+                '/app/web',
+                'added by the php runtime builder',
+                'gcr.io/google-appengine/php71:latest',
+                [],
+                '\\Google\\Cloud\\Runtimes\\Builder\\Exception\\GoogleCloudVersionException'
+            ],
+            [
                 // PHP 5.6
                 __DIR__ . '/test_data/php56',
                 null,

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_no_composer/app.yaml
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_no_composer/app.yaml
@@ -1,0 +1,6 @@
+env: flex
+runtime: php
+
+runtime_config:
+  enable_stackdriver_integration: true
+  document_root: web

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_no_google_cloud/app.yaml
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_no_google_cloud/app.yaml
@@ -1,0 +1,6 @@
+env: flex
+runtime: php
+
+runtime_config:
+  enable_stackdriver_integration: true
+  document_root: web

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_no_google_cloud/composer.json
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_no_google_cloud/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "google/cloud-logging": "*"
+    }
+}

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_old_google_cloud/app.yaml
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_old_google_cloud/app.yaml
@@ -1,0 +1,6 @@
+env: flex
+runtime: php
+
+runtime_config:
+  enable_stackdriver_integration: true
+  document_root: web

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_old_google_cloud/composer.json
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_old_google_cloud/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "google/cloud": "^0.32"
+    }
+}

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_simple/app.yaml
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_simple/app.yaml
@@ -1,0 +1,6 @@
+env: flex
+runtime: php
+
+runtime_config:
+  enable_stackdriver_integration: true
+  document_root: web

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_simple/composer.json
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_simple/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "google/cloud": "^0.34.1"
+    }
+}

--- a/php-base/Dockerfile
+++ b/php-base/Dockerfile
@@ -62,6 +62,9 @@ ENV NGINX_DIR=/etc/nginx \
 
 # Install build scripts - composer, nginx, php
 COPY build-scripts /build-scripts
+# Files for stackdriver setup
+COPY stackdriver-files /stackdriver-files
+
 RUN chown www-data /build-scripts
 
 ARG RUNTIME_DISTRIBUTION="gcp-php-runtime-jessie"

--- a/php-base/stackdriver-files/batch-daemon.conf
+++ b/php-base/stackdriver-files/batch-daemon.conf
@@ -1,0 +1,11 @@
+[program:batch-daemon]
+command = php -d auto_prepend_file='' -d disable_functions='' /app/vendor/bin/google-cloud-batch daemon
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes=0
+user = www-data
+autostart = true
+autorestart = true
+priority = 5
+stopwaitsecs = 20

--- a/php-base/stackdriver-files/enable_stackdriver_integration.sh
+++ b/php-base/stackdriver-files/enable_stackdriver_integration.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,17 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Dockerfile for App Engine Flexible environment for PHP
 
-FROM {{ base_image }}
+# A shell script for installing composer
+set -xe
 
-{{ env_string }}
+# To start the batch daemon
+cp /stackdriver-files/batch-daemon.conf /etc/supervisor/conf.d
 
-COPY . $APP_DIR
-RUN chown -R www-data.www-data $APP_DIR
-RUN /build-scripts/composer.sh
-
-RUN /bin/bash /build-scripts/move-config-files.sh
-RUN /bin/bash /build-scripts/lockdown.sh
-
-{{ enable_stackdriver_cmd }}
+# For enabling automatic error reporting
+cp /stackdriver-files/stackdriver-errorreporting.ini ${PHP_DIR}/lib/conf.d

--- a/php-base/stackdriver-files/stackdriver-errorreporting.ini
+++ b/php-base/stackdriver-files/stackdriver-errorreporting.ini
@@ -1,0 +1,2 @@
+# Automatic error reporting
+auto_prepend_file='/app/vendor/google/cloud/src/ErrorReporting/prepend.php'


### PR DESCRIPTION
This PR adds `enable_stackdriver_integration` field in runtime_config. If it's set to true-ish value, the runtime builder will first check if there's a compatible google/cloud is there in `composer.json`, then add a command to enable stackdriver integration and set `IS_BATCH_DAEMON_RUNNING` env to true.