### PR TITLE
Build stackdriver_trace extension from a GitHub release version archive.

### DIFF
--- a/deb-package-builder/extensions/stackdriver_trace/build.sh
+++ b/deb-package-builder/extensions/stackdriver_trace/build.sh
@@ -7,13 +7,13 @@ source ${DEB_BUILDER_DIR}/extensions/functions.sh
 echo "Building stackdriver trace for gcp-php${SHORT_VERSION}"
 
 PNAME="gcp-php${SHORT_VERSION}-stackdriver-trace"
-EXT_VERSION="0.1.0"
+EXT_VERSION="0.1.1"
 
 if [ ${SHORT_VERSION} == '56' ]; then
     echo "PHP 5.6 is not supported"
     exit 0
 fi
 
-download_from_tarball https://github.com/GoogleCloudPlatform/stackdriver-trace-php-extension/archive/master.tar.gz ${EXT_VERSION}
+download_from_tarball https://github.com/GoogleCloudPlatform/stackdriver-trace-php-extension/archive/v${EXT_VERSION}.tar.gz ${EXT_VERSION}
 
 build_package stackdriver_trace


### PR DESCRIPTION
Use the release archive from GitHub rather than master.

Also build v0.1.1 (fixes PHP 7.0 and segfaults for non-string labels)