### PR TITLE
Removed `COMPOSER_GITHUB_OAUTH_TOKEN` env var.

### DIFF
--- a/builder/gen-dockerfile/src/Builder/Exception/RemovedEnvVarException.php
+++ b/builder/gen-dockerfile/src/Builder/Exception/RemovedEnvVarException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Runtimes\Builder\Exception;
+
+class RemovedEnvVarException extends \RuntimeException
+{
+}

--- a/builder/gen-dockerfile/src/Builder/GenFilesCommand.php
+++ b/builder/gen-dockerfile/src/Builder/GenFilesCommand.php
@@ -35,6 +35,9 @@ class GenFilesCommand extends Command
     const DEFAULT_YAML_PATH = 'app.yaml';
     const DEFAULT_FRONT_CONTROLLER_FILE = 'index.php';
     const STACKDRIVER_INTEGRATION_ENV = 'ENABLE_STACKDRIVER_INTEGRATION';
+    const REMOVED_ENV_VARS = [
+        'COMPOSER_GITHUB_OAUTH_TOKEN'
+    ];
 
     /* @var string */
     private $workspace;
@@ -204,6 +207,20 @@ Using PHP version 7.1.x...</info>
                 . "'runtime_config'. Remove the following keys in "
                 . "'env_variables': "
                 . implode(" ", $errorKeys)
+            );
+        }
+        $removedEnvVars = [];
+        foreach (self::REMOVED_ENV_VARS as $k) {
+            if (array_key_exists($k, $ret)) {
+                $removedEnvVars[] = $k;
+            }
+        }
+        if (count($removedEnvVars) > 0) {
+            throw new RemovedEnvVarException(
+                "There are environment variables which are no more"
+                . "supported. Remove the following keys in "
+                . "'env_variables': "
+                . implode(" ", $removedEnvVars)
             );
         }
         return $ret;

--- a/builder/gen-dockerfile/tests/GenFilesCommandTest.php
+++ b/builder/gen-dockerfile/tests/GenFilesCommandTest.php
@@ -140,6 +140,17 @@ class GenFilesCommandTest extends \PHPUnit_Framework_TestCase
                 ]
             ],
             [
+                // Removed env var
+                __DIR__ . '/test_data/removed_env_var',
+                null,
+                '',
+                '',
+                '',
+                '',
+                [],
+                '\\Google\\Cloud\\Runtimes\\Builder\\Exception\\RemovedEnvVarException'
+            ],
+            [
                 // stackdriver simple case
                 __DIR__ . '/test_data/stackdriver_simple',
                 null,

--- a/builder/gen-dockerfile/tests/test_data/removed_env_var/app.yaml
+++ b/builder/gen-dockerfile/tests/test_data/removed_env_var/app.yaml
@@ -1,0 +1,8 @@
+env: flex
+runtime: php
+
+runtime_config:
+  document_root: /app
+
+env_variables:
+  COMPOSER_GITHUB_OAUTH_TOKEN: my_secret

--- a/php-base/build-scripts/composer.sh
+++ b/php-base/build-scripts/composer.sh
@@ -59,20 +59,6 @@ EOF
             rm -rf /var/lib/apt/lists/*
         fi
     fi
-    # Handle custom oauth keys (Adapted from https://github.com/heroku/heroku-buildpack-php/blob/master/bin/compile)
-    COMPOSER_GITHUB_OAUTH_TOKEN=${COMPOSER_GITHUB_OAUTH_TOKEN:-}
-    if [[ -n "$COMPOSER_GITHUB_OAUTH_TOKEN" ]]; then
-        if curl --fail --silent -H "Authorization: token $COMPOSER_GITHUB_OAUTH_TOKEN" https://api.github.com/rate_limit > /dev/null; then
-            su -m www-data -c "php /usr/local/bin/composer \
-              config -g github-oauth.github.com ${COMPOSER_GITHUB_OAUTH_TOKEN} &> /dev/null"
-            # redirect outdated version warnings (Composer sends those to STDOUT instead of STDERR)
-            echo 'Using $COMPOSER_GITHUB_OAUTH_TOKEN for GitHub OAuth.'
-        else
-            echo 'Invalid $COMPOSER_GITHUB_OAUTH_TOKEN for GitHub OAuth!'
-        fi
-    fi
-    # no need for the token to stay around in the env
-    unset COMPOSER_GITHUB_OAUTH_TOKEN
 
     # Workaround for https://github.com/docker/docker/issues/6047
     # We want to remove when Container Builder starts to use newer Docker.

--- a/php-onbuild/README.md
+++ b/php-onbuild/README.md
@@ -330,7 +330,7 @@ authenticate against github.com`, it means your IP (or effectively the IP of
 the ComputeEngine builder VM when you deploy to AppEngine) exceeded the
 API rate limit for anonymous access and composer can now only use the
 (significantly slower) VCS source method for fetching packages. To fix it,
-you can add a file named `auth.json` besides `composer.json`.
+you can add a file named `auth.json` besides `composer.json` ([examples](https://cloud.google.com/appengine/docs/flexible/php/using-php-libraries#using_private_repositories)).
 
 As this is your personal credential for GitHub, please make sure you do not
 commit this token to your repository.

--- a/php-onbuild/README.md
+++ b/php-onbuild/README.md
@@ -330,8 +330,7 @@ authenticate against github.com`, it means your IP (or effectively the IP of
 the ComputeEngine builder VM when you deploy to AppEngine) exceeded the
 API rate limit for anonymous access and composer can now only use the
 (significantly slower) VCS source method for fetching packages. To fix it,
-you can add a environment variable `COMPOSER_GITHUB_OAUTH_TOKEN` to your
-deployment (`app.yaml` or `Dockerfile` are both fine).
+you can add a file named `auth.json` besides `composer.json`.
 
 As this is your personal credential for GitHub, please make sure you do not
 commit this token to your repository.


### PR DESCRIPTION
The runtime builder will throw an error when it's specified.

fixes #339 