### PR TITLE
Configure longer keepalive timeout for GCP loadbalancer.

### DIFF
--- a/php-base/nginx.conf
+++ b/php-base/nginx.conf
@@ -38,7 +38,8 @@ http {
 
     sendfile        on;
 
-    keepalive_timeout  65;
+    keepalive_timeout  650;
+    keepalive_requests 10000;
 
     map $http_x_forwarded_proto $fastcgi_https {
         default '';


### PR DESCRIPTION
See also:
https://blog.percy.io/tuning-nginx-behind-google-cloud-platform-http-s-load-balancer-305982ddb340