### PR TITLE
Added a necessary dep for the integration test

### DIFF
--- a/testapps/integration-individual-packages/composer.json
+++ b/testapps/integration-individual-packages/composer.json
@@ -6,6 +6,7 @@
   },
   "require": {
     "php": "5.6.*|7.0.*|7.1.*",
+    "ext-grpc": "*",
     "silex/silex": "^1.3",
     "google/cloud-logging": "^1.3.1",
     "google/cloud-error-reporting": "^0.4.1"


### PR DESCRIPTION
It's needed because google/cloud-error-reporting needs grpc extension.