### PR TITLE
Make local development easier

### DIFF
--- a/php-base/build-scripts/lockdown.sh
+++ b/php-base/build-scripts/lockdown.sh
@@ -20,14 +20,18 @@ else
     set -e
 fi
 
-echo "Locking down the document root..."
+if [ "${LOCAL_DEV_ENVIRONMENT}" != "true" ]; then
+    echo "Locking down the document root..."
 
-# Lock down the DOCUMENT_ROOT
-chown -R root.www-data ${DOCUMENT_ROOT}
-chmod -R 550 ${DOCUMENT_ROOT}
+    # Lock down the DOCUMENT_ROOT
+    chown -R root.www-data ${DOCUMENT_ROOT}
+    chmod -R 550 ${DOCUMENT_ROOT}
 
-# Change the www-data's shell back to /usr/sbin/nologin
-chsh -s /usr/sbin/nologin www-data
+    # Change the www-data's shell back to /usr/sbin/nologin
+    chsh -s /usr/sbin/nologin www-data
+else
+    echo "WARNING: Not locking down document root. Local dev environment set"
+fi
 
 # Enable suhosin for PHP 5.6.x
 if [ -x "${PHP56_DIR}/bin/php56-enmod" ]; then


### PR DESCRIPTION
When doing local development and attempting to replicate the live environment, the ability to use local volumes replicated into the docker container are crucial. Unfortunately this file will then lock down the files inside the development environment as well as the files in the docker container. This adds an environment variable to turn off the lock down in the case of attempting to do the above.