### PR TITLE
Use expectException instead

### DIFF
--- a/builder/gen-dockerfile/tests/GenFilesCommandTest.php
+++ b/builder/gen-dockerfile/tests/GenFilesCommandTest.php
@@ -81,7 +81,7 @@ class GenFilesCommandTest extends \PHPUnit_Framework_TestCase
                 ];
         }
         if ($expectedException !== null) {
-            $this->setExpectedExceptionRegExp($expectedException);
+            $this->expectException($expectedException);
         }
         // Copy all the files to the test dir
         foreach (self::$files as $file) {


### PR DESCRIPTION
Somehow `setExpectedExceptionRegExp` changed the bahavior with the phpunit 5.7.23.
I think it's safer to use `expectException`.

