### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/builder/gen-dockerfile/tests/GenFilesCommandTest.php
+++ b/builder/gen-dockerfile/tests/GenFilesCommandTest.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\Runtimes\Builder;
 
 use Symfony\Component\Console\Tester\CommandTester;
+use PHPUnit\Framework\TestCase;
 
-class GenFilesCommandTest extends \PHPUnit_Framework_TestCase
+class GenFilesCommandTest extends TestCase
 {
     public static $testDir;
 

--- a/check-versions/tests/VersionTest.php
+++ b/check-versions/tests/VersionTest.php
@@ -16,8 +16,9 @@
  */
 
 use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
 
-class VersionTest extends \PHPUnit_Framework_TestCase
+class VersionTest extends TestCase
 {
     private static $versions;
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.0"
+        "friendsofphp/php-cs-fixer": "~2.0",
+        "phpunit/phpunit": "^4.8.35"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "467bef906926f9627bb861e5e27e1cb2",
-    "content-hash": "52854c907a1557741038d86c2941a12a",
+    "content-hash": "0a9b5a945d27e85f1385a4d3c9e696ee",
     "packages": [],
     "packages-dev": [
         {
@@ -60,7 +59,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -125,7 +124,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-12-01 06:18:06"
+            "time": "2016-12-01T06:18:06+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -187,7 +186,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-10-08 15:01:37"
+            "time": "2016-10-08T15:01:37+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -238,7 +237,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-11-18 17:47:58"
+            "time": "2016-11-18T17:47:58+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -296,7 +295,7 @@
                 "stream",
                 "uri"
             ],
-            "time": "2016-06-24 23:00:38"
+            "time": "2016-06-24T23:00:38+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -350,7 +349,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -395,7 +394,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -442,7 +441,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -505,7 +504,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -567,7 +566,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -614,7 +613,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -655,7 +654,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -699,7 +698,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -748,20 +747,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.30",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a534e04d0bd39c557c2881c341efd06fa6f1292a",
-                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {
@@ -820,7 +819,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-01 17:05:48"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -876,7 +875,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "psr/http-message",
@@ -926,7 +925,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -973,7 +972,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1037,7 +1036,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19 09:18:40"
+            "time": "2016-11-19T09:18:40+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1089,7 +1088,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1139,7 +1138,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1206,7 +1205,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1257,7 +1256,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1310,7 +1309,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1345,7 +1344,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -1402,7 +1401,7 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-09-06T10:55:00+00:00"
         },
         {
             "name": "symfony/console",
@@ -1465,7 +1464,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-16 22:18:16"
+            "time": "2016-11-16T22:18:16+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1522,7 +1521,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-16 22:18:16"
+            "time": "2016-11-16T22:18:16+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -1578,7 +1577,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:22:48"
+            "time": "2016-07-30T07:22:48+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1638,7 +1637,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-13 06:29:04"
+            "time": "2016-10-13T06:29:04+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1687,7 +1686,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-24 00:46:43"
+            "time": "2016-11-24T00:46:43+00:00"
         },
         {
             "name": "symfony/finder",
@@ -1736,7 +1735,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 08:11:03"
+            "time": "2016-11-03T08:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1795,7 +1794,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php54",
@@ -1853,7 +1852,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/process",
@@ -1902,7 +1901,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-24 10:40:28"
+            "time": "2016-11-24T10:40:28+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -1951,7 +1950,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:43:10"
+            "time": "2016-06-29T05:43:10+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2006,7 +2005,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-18 21:17:59"
+            "time": "2016-11-18T21:17:59+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2056,7 +2055,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/perf-dashboard/deployment-latency/tests/CollectDeploymentLatencyTest.php
+++ b/perf-dashboard/deployment-latency/tests/CollectDeploymentLatencyTest.php
@@ -18,8 +18,9 @@
 namespace Google\Cloud\PerfDashBoard;
 
 use Google\Cloud\BigQuery\BigQueryClient;
+use PHPUnit\Framework\TestCase;
 
-class CollectDeploymentLatencyTest extends \PHPUnit_Framework_TestCase
+class CollectDeploymentLatencyTest extends TestCase
 {
     const DEPLOYMENT_MAX_RETRY = 5;
     const DATASET_ID = 'deployment_latency';

--- a/php-base/composer.json
+++ b/php-base/composer.json
@@ -3,6 +3,6 @@
         "composer/semver": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "^4.8.35"
     }
 }

--- a/php-base/composer.lock
+++ b/php-base/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a80ba8af17a8f429f98463d3732a0a7",
+    "content-hash": "f21a2ddfe17b41374991039269d6775a",
     "packages": [
         {
             "name": "composer/semver",
@@ -583,16 +583,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.35",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/791b1a67c25af50e230f841ee7a9c6eba507dc87",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {
@@ -651,7 +651,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06T05:18:07+00:00"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/php-base/tests/DetectPhpVersionTest.php
+++ b/php-base/tests/DetectPhpVersionTest.php
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
+use PHPUnit\Framework\TestCase;
+
 require_once(__DIR__ . "/../build-scripts/detect_php_version.php");
 
-class DetectPhpVersionTest extends \PHPUnit_Framework_TestCase
+class DetectPhpVersionTest extends TestCase
 {
     const PHP_71 = '7.1.3';
     const PHP_70 = '7.0.17';

--- a/php-base/tests/InstallExtensionsTest.php
+++ b/php-base/tests/InstallExtensionsTest.php
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
+use PHPUnit\Framework\TestCase;
+
 require_once(__DIR__ . "/../build-scripts/install_extensions.php");
 
-class InstallExtensionsTest extends \PHPUnit_Framework_TestCase
+class InstallExtensionsTest extends TestCase
 {
     public function testDetectsPackagedExtensions()
     {

--- a/testapps/build_pipeline/tests/tests/EndToEndTest.php
+++ b/testapps/build_pipeline/tests/tests/EndToEndTest.php
@@ -20,8 +20,9 @@ namespace Google\Cloud\tests;
 use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use PHPUnit\Framework\TestCase;
 
-class EndToEndTest extends \PHPUnit_Framework_TestCase
+class EndToEndTest extends TestCase
 {
     use EventuallyConsistentTestTrait;
 

--- a/testapps/build_pipeline_php56/tests/tests/EndToEndTest.php
+++ b/testapps/build_pipeline_php56/tests/tests/EndToEndTest.php
@@ -20,8 +20,9 @@ namespace Google\Cloud\tests;
 use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use PHPUnit\Framework\TestCase;
 
-class EndToEndTest extends \PHPUnit_Framework_TestCase
+class EndToEndTest extends TestCase
 {
     use EventuallyConsistentTestTrait;
 

--- a/testapps/builder_test/tests/DockerfileTest.php
+++ b/testapps/builder_test/tests/DockerfileTest.php
@@ -16,7 +16,9 @@
  */
 namespace Google\Cloud\tests;
 
-class DockerfileTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DockerfileTest extends TestCase
 {
     public function testDockerfile()
     {

--- a/testapps/integration-individual-packages/composer.json
+++ b/testapps/integration-individual-packages/composer.json
@@ -14,7 +14,7 @@
   "require-dev": {
     "behat/mink": "^1.7",
     "behat/mink-goutte-driver": "^1.2",
-    "phpunit/phpunit": "~4",
+    "phpunit/phpunit": "~4.8.35",
     "symfony/browser-kit": "^3.0",
     "symfony/http-kernel": "^3.0",
     "google/cloud-tools": "^0.6"

--- a/testapps/integration/composer.json
+++ b/testapps/integration/composer.json
@@ -12,7 +12,7 @@
   "require-dev": {
     "behat/mink": "^1.7",
     "behat/mink-goutte-driver": "^1.2",
-    "phpunit/phpunit": "~4",
+    "phpunit/phpunit": "~4.8.35",
     "symfony/browser-kit": "^3.0",
     "symfony/http-kernel": "^3.0",
     "google/cloud-tools": "^0.6"

--- a/testapps/php56/tests/PHP56Test.php
+++ b/testapps/php56/tests/PHP56Test.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\tests;
 
 use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
 
-class PHP56Test extends \PHPUnit_Framework_TestCase
+class PHP56Test extends TestCase
 {
     private $client;
 

--- a/testapps/php56_custom/tests/PHP56CustomTest.php
+++ b/testapps/php56_custom/tests/PHP56CustomTest.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\tests;
 
 use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
 
-class PHP56CustomTest extends \PHPUnit_Framework_TestCase
+class PHP56CustomTest extends TestCase
 {
     private $client;
 

--- a/testapps/php56_custom_configs/tests/PHP56CustomConfigTest.php
+++ b/testapps/php56_custom_configs/tests/PHP56CustomConfigTest.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\tests;
 
 use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
 
-class PHP56CustomConfigTest extends \PHPUnit_Framework_TestCase
+class PHP56CustomConfigTest extends TestCase
 {
     private $client;
 

--- a/testapps/php56_extensions/composer.json
+++ b/testapps/php56_extensions/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^5.6",
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.35",
         "ext-amqp": "*",
         "ext-bcmath": "*",
         "ext-calendar": "*",

--- a/testapps/php56_extensions/tests/CassandraTest.php
+++ b/testapps/php56_extensions/tests/CassandraTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class CassandraTest extends \PHPUnit_Framework_TestCase
+class CassandraTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php56_extensions/tests/EvTest.php
+++ b/testapps/php56_extensions/tests/EvTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class EvTest extends \PHPUnit_Framework_TestCase
+class EvTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php56_extensions/tests/EventTest.php
+++ b/testapps/php56_extensions/tests/EventTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class EventTest extends \PHPUnit_Framework_TestCase
+class EventTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php56_extensions/tests/ExtensionsLoadedTest.php
+++ b/testapps/php56_extensions/tests/ExtensionsLoadedTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ExtensionsLoadedTest extends \PHPUnit_Framework_TestCase
+class ExtensionsLoadedTest extends TestCase
 {
     /**
      * @dataProvider extensions

--- a/testapps/php56_extensions/tests/GdTest.php
+++ b/testapps/php56_extensions/tests/GdTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class GdTest extends \PHPUnit_Framework_TestCase
+class GdTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php56_extensions/tests/GmpTest.php
+++ b/testapps/php56_extensions/tests/GmpTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class GmpTest extends \PHPUnit_Framework_TestCase
+class GmpTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php56_extensions/tests/ImagickTest.php
+++ b/testapps/php56_extensions/tests/ImagickTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ImagickTest extends \PHPUnit_Framework_TestCase
+class ImagickTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php56_extensions/tests/LibSodiumTest.php
+++ b/testapps/php56_extensions/tests/LibSodiumTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class LibsodiumTest extends \PHPUnit_Framework_TestCase
+class LibsodiumTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php56_extensions/tests/OauthTest.php
+++ b/testapps/php56_extensions/tests/OauthTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class OauthTest extends \PHPUnit_Framework_TestCase
+class OauthTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php56_extensions/tests/PhalconTest.php
+++ b/testapps/php56_extensions/tests/PhalconTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class PhalconTest extends \PHPUnit_Framework_TestCase
+class PhalconTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php56_extensions/tests/ProtobufTest.php
+++ b/testapps/php56_extensions/tests/ProtobufTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ProtobufTest extends \PHPUnit_Framework_TestCase
+class ProtobufTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php56_extensions/tests/RdkafkaTest.php
+++ b/testapps/php56_extensions/tests/RdkafkaTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class RdkafkaTest extends \PHPUnit_Framework_TestCase
+class RdkafkaTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php56_nginx_conf/tests/PHP56NginxConfTest.php
+++ b/testapps/php56_nginx_conf/tests/PHP56NginxConfTest.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\tests;
 
 use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
 
-class PHP56NginxConfTest extends \PHPUnit_Framework_TestCase
+class PHP56NginxConfTest extends TestCase
 {
     private $client;
 

--- a/testapps/php70_custom/tests/tests/PHP7CustomTest.php
+++ b/testapps/php70_custom/tests/tests/PHP7CustomTest.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\tests;
 
 use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
 
-class PHP7CustomTest extends \PHPUnit_Framework_TestCase
+class PHP7CustomTest extends TestCase
 {
     private $client;
 

--- a/testapps/php70_extensions/composer.json
+++ b/testapps/php70_extensions/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "7.0.*",
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.35",
         "ext-amqp": "*",
         "ext-apm": "*",
         "ext-bcmath": "*",

--- a/testapps/php70_extensions/tests/CassandraTest.php
+++ b/testapps/php70_extensions/tests/CassandraTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class CassandraTest extends \PHPUnit_Framework_TestCase
+class CassandraTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php70_extensions/tests/EvTest.php
+++ b/testapps/php70_extensions/tests/EvTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class EvTest extends \PHPUnit_Framework_TestCase
+class EvTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php70_extensions/tests/EventTest.php
+++ b/testapps/php70_extensions/tests/EventTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class EventTest extends \PHPUnit_Framework_TestCase
+class EventTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php70_extensions/tests/ExtensionsLoadedTest.php
+++ b/testapps/php70_extensions/tests/ExtensionsLoadedTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ExtensionsLoadedTest extends \PHPUnit_Framework_TestCase
+class ExtensionsLoadedTest extends TestCase
 {
     /**
      * @dataProvider extensions

--- a/testapps/php70_extensions/tests/GdTest.php
+++ b/testapps/php70_extensions/tests/GdTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class GdTest extends \PHPUnit_Framework_TestCase
+class GdTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php70_extensions/tests/GmpTest.php
+++ b/testapps/php70_extensions/tests/GmpTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class GmpTest extends \PHPUnit_Framework_TestCase
+class GmpTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php70_extensions/tests/ImagickTest.php
+++ b/testapps/php70_extensions/tests/ImagickTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ImagickTest extends \PHPUnit_Framework_TestCase
+class ImagickTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php70_extensions/tests/LibSodiumTest.php
+++ b/testapps/php70_extensions/tests/LibSodiumTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class LibsodiumTest extends \PHPUnit_Framework_TestCase
+class LibsodiumTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php70_extensions/tests/OauthTest.php
+++ b/testapps/php70_extensions/tests/OauthTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class OauthTest extends \PHPUnit_Framework_TestCase
+class OauthTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php70_extensions/tests/PhalconTest.php
+++ b/testapps/php70_extensions/tests/PhalconTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class PhalconTest extends \PHPUnit_Framework_TestCase
+class PhalconTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php70_extensions/tests/ProtobufTest.php
+++ b/testapps/php70_extensions/tests/ProtobufTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ProtobufTest extends \PHPUnit_Framework_TestCase
+class ProtobufTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php70_extensions/tests/RdkafkaTest.php
+++ b/testapps/php70_extensions/tests/RdkafkaTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class RdkafkaTest extends \PHPUnit_Framework_TestCase
+class RdkafkaTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php71_custom/tests/tests/PHP71CustomTest.php
+++ b/testapps/php71_custom/tests/tests/PHP71CustomTest.php
@@ -17,8 +17,9 @@
 namespace Google\Cloud\tests;
 
 use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
 
-class PHP7CustomTest extends \PHPUnit_Framework_TestCase
+class PHP7CustomTest extends TestCase
 {
     private $client;
 

--- a/testapps/php71_e2e/tests/tests/EndToEndTest.php
+++ b/testapps/php71_e2e/tests/tests/EndToEndTest.php
@@ -20,8 +20,9 @@ namespace Google\Cloud\tests;
 use Google\Cloud\TestUtils\EventuallyConsistentTestTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use PHPUnit\Framework\TestCase;
 
-class EndToEndTest extends \PHPUnit_Framework_TestCase
+class EndToEndTest extends TestCase
 {
     use EventuallyConsistentTestTrait;
 

--- a/testapps/php71_extensions/composer.json
+++ b/testapps/php71_extensions/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "7.1.*",
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.35",
         "ext-amqp": "*",
         "ext-apm": "*",
         "ext-bcmath": "*",

--- a/testapps/php71_extensions/tests/CassandraTest.php
+++ b/testapps/php71_extensions/tests/CassandraTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class CassandraTest extends \PHPUnit_Framework_TestCase
+class CassandraTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php71_extensions/tests/EvTest.php
+++ b/testapps/php71_extensions/tests/EvTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class EvTest extends \PHPUnit_Framework_TestCase
+class EvTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php71_extensions/tests/EventTest.php
+++ b/testapps/php71_extensions/tests/EventTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class EventTest extends \PHPUnit_Framework_TestCase
+class EventTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php71_extensions/tests/ExtensionsLoadedTest.php
+++ b/testapps/php71_extensions/tests/ExtensionsLoadedTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ExtensionsLoadedTest extends \PHPUnit_Framework_TestCase
+class ExtensionsLoadedTest extends TestCase
 {
     /**
      * @dataProvider extensions

--- a/testapps/php71_extensions/tests/GdTest.php
+++ b/testapps/php71_extensions/tests/GdTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class GdTest extends \PHPUnit_Framework_TestCase
+class GdTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php71_extensions/tests/GmpTest.php
+++ b/testapps/php71_extensions/tests/GmpTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class GmpTest extends \PHPUnit_Framework_TestCase
+class GmpTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php71_extensions/tests/ImagickTest.php
+++ b/testapps/php71_extensions/tests/ImagickTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ImagickTest extends \PHPUnit_Framework_TestCase
+class ImagickTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php71_extensions/tests/LibSodiumTest.php
+++ b/testapps/php71_extensions/tests/LibSodiumTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class LibsodiumTest extends \PHPUnit_Framework_TestCase
+class LibsodiumTest extends TestCase
 {
     public function testExtensionLoaded()
     {

--- a/testapps/php71_extensions/tests/OauthTest.php
+++ b/testapps/php71_extensions/tests/OauthTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class OauthTest extends \PHPUnit_Framework_TestCase
+class OauthTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php71_extensions/tests/PhalconTest.php
+++ b/testapps/php71_extensions/tests/PhalconTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class PhalconTest extends \PHPUnit_Framework_TestCase
+class PhalconTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php71_extensions/tests/ProtobufTest.php
+++ b/testapps/php71_extensions/tests/ProtobufTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class ProtobufTest extends \PHPUnit_Framework_TestCase
+class ProtobufTest extends TestCase
 {
     private $success = false;
 

--- a/testapps/php71_extensions/tests/RdkafkaTest.php
+++ b/testapps/php71_extensions/tests/RdkafkaTest.php
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use PHPUnit\Framework\TestCase;
 
-class RdkafkaTest extends \PHPUnit_Framework_TestCase
+class RdkafkaTest extends TestCase
 {
     private $success = false;
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.