### PR TITLE
Re-enable the libsodium test on php 7.2

### DIFF
--- a/testapps/php72_extensions/tests/LibSodiumTest.php
+++ b/testapps/php72_extensions/tests/LibSodiumTest.php
@@ -18,11 +18,6 @@ use PHPUnit\Framework\TestCase;
 
 class LibsodiumTest extends TestCase
 {
-    public function setUp()
-    {
-        $this->markTestSkipped('FIXME: need to compile sodium in php 7.2');
-    }
-
     public function testExtensionLoaded()
     {
         $this->assertTrue(extension_loaded('sodium'));


### PR DESCRIPTION
New PHP 7.2 package is available on cloud apt.