### PR TITLE
Fix version check for building mongo

### DIFF
--- a/deb-package-builder/extensions/mongo/build.sh
+++ b/deb-package-builder/extensions/mongo/build.sh
@@ -7,7 +7,7 @@ echo "Building mongo for gcp-php${SHORT_VERSION}"
 PNAME="gcp-php${SHORT_VERSION}-mongo"
 
 # Download the source
-if [ ${SHORT_VERSION} != '5.6' ]; then
+if [ ${SHORT_VERSION} != '56' ]; then
     echo "deprecated mongo ext supported only on PHP 5.6"
     exit 0
 else


### PR DESCRIPTION
The `$SHORT_VERSION` env variable is `56`, not `5.6`.

Verified that it does in fact build now.