### PR TITLE
Lock redis extension to 3.1.6

### DIFF
--- a/deb-package-builder/extensions/redis/build.sh
+++ b/deb-package-builder/extensions/redis/build.sh
@@ -9,6 +9,6 @@ echo "Building redis for gcp-php${SHORT_VERSION}"
 PNAME="gcp-php${SHORT_VERSION}-redis"
 
 # Download the source
-download_from_pecl redis
+download_from_pecl redis 3.1.6
 
 build_package redis


### PR DESCRIPTION
4.0.0 has breaking changes. We will need a way to have both (similar to phalcon and swoole extensions).