### PR TITLE
Change the way we check the required version of the dependency

### DIFF
--- a/builder/gen-dockerfile/src/ValidateGoogleCloud.php
+++ b/builder/gen-dockerfile/src/ValidateGoogleCloud.php
@@ -91,13 +91,18 @@ class ValidateGoogleCloud
                     "no available matching version of $package"
                 );
             }
+            $found = false;
             foreach ($filtered as $version) {
-                if (Comparator::lessThan($version, $minimumVersionMap[$package])) {
-                    throw new GoogleCloudVersionException(
-                        "stackdriver integration needs $package "
-                        . $minimumVersionMap[$package] . ' or higher'
-                    );
+                if (Comparator::greaterThanOrEqualTo($version, $minimumVersionMap[$package])) {
+                    $found = true;
+                    break;
                 }
+            }
+            if ($found === false) {
+                throw new GoogleCloudVersionException(
+                    "stackdriver integration needs $package "
+                    . $minimumVersionMap[$package] . ' or higher'
+                );
             }
         }
 

--- a/builder/gen-dockerfile/tests/GenFilesCommandTest.php
+++ b/builder/gen-dockerfile/tests/GenFilesCommandTest.php
@@ -203,6 +203,21 @@ class GenFilesCommandTest extends TestCase
                 ]
             ],
             [
+                // stackdriver wildcard dep
+                __DIR__ . '/test_data/stackdriver_wildcard',
+                null,
+                '',
+                '/app/web',
+                'added by the php runtime builder',
+                'gcr.io/google-appengine/php72:latest',
+                ["COMPOSER_FLAGS='--no-dev --prefer-dist' \\\n",
+                 "FRONT_CONTROLLER_FILE='index.php' \\\n",
+                 "DETECTED_PHP_VERSION='7.2' \\\n",
+                 "IS_BATCH_DAEMON_RUNNING='true' \n",
+                 "enable_stackdriver_integration.sh"
+                ]
+            ],
+            [
                 // stackdriver individual packages
                 __DIR__ . '/test_data/stackdriver_individual',
                 null,
@@ -224,7 +239,7 @@ class GenFilesCommandTest extends TestCase
                 '',
                 '/app/web',
                 'added by the php runtime builder',
-                'gcr.io/google-appengine/php71:latest',
+                'gcr.io/google-appengine/php72:latest',
                 [],
                 '\\Google\\Cloud\\Runtimes\\Builder\\Exception\\GoogleCloudVersionException'
             ],

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_old_logging/composer.json
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_old_logging/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "google/cloud-logging": "^1.2.0",
+        "google/cloud-logging": "<=1.2.0",
         "google/cloud-error-reporting": "^0.4.1"
     }
 }

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_wildcard/app.yaml
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_wildcard/app.yaml
@@ -1,0 +1,6 @@
+env: flex
+runtime: php
+
+runtime_config:
+  enable_stackdriver_integration: true
+  document_root: web

--- a/builder/gen-dockerfile/tests/test_data/stackdriver_wildcard/composer.json
+++ b/builder/gen-dockerfile/tests/test_data/stackdriver_wildcard/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "google/cloud": "*"
+    }
+}


### PR DESCRIPTION
There are still some cases for false negative where the direct
constrant is ok and other indirect dependency has a problem.

Although the issue is not completely fixed, this logic change allows
more legitimate cases which has been failing with the previous code.

It will alleviate #426