### PR TITLE
Update integration-individual package dependencies

### DIFF
--- a/testapps/integration-individual-packages/composer.json
+++ b/testapps/integration-individual-packages/composer.json
@@ -9,9 +9,8 @@
     "ext-grpc": "*",
     "ext-protobuf": "*",
     "silex/silex": "^1.3",
-    "google/cloud-logging": "^1.7.0",
-    "google/cloud-error-reporting": "^0.7.0",
-    "google/gax": "^0.27"
+    "google/cloud-logging": "^1.11",
+    "google/cloud-error-reporting": "^0.10"
   },
   "require-dev": {
     "behat/mink": "^1.7",


### PR DESCRIPTION
The combination of dependencies with the latest updates failed to load
a compatible gax version.

The integration app was throwing:
```
Uncaught Error: Class 'Google\ApiCore\CredentialsWrapper' not found in
/app/vendor/google/cloud-core/src/GrpcTrait.php:102
```