### PR TITLE
Only track ubuntu16 deployment latency

### DIFF
--- a/perf-dashboard/deployment-latency/tests/CollectDeploymentLatencyTest.php
+++ b/perf-dashboard/deployment-latency/tests/CollectDeploymentLatencyTest.php
@@ -61,7 +61,6 @@ class CollectDeploymentLatencyTest extends TestCase
             '7.2'
         ];
         $types = [
-            'debian8',
             'ubuntu16'
         ];
         $gcloudTrack = getenv('GCLOUD_TRACK') === 'beta' ? 'beta' : '';


### PR DESCRIPTION
This is causing occasional timeouts on the system tracking deployments and you can only deploy ubuntu now.