### PR TITLE
Removed Phalcon from unavailable extensions

### DIFF
--- a/php-base/build-scripts/src/InstallExtensions.php
+++ b/php-base/build-scripts/src/InstallExtensions.php
@@ -88,7 +88,6 @@ class InstallExtensions
         'memcache' => ['7.0', '7.1', '7.2'],
         'mongo' => ['7.0', '7.1', '7.2'],
         'opencensus' => ['5.6'],
-        'phalcon' => ['7.1', '7.2'],
         'stackdriver_debugger' => ['5.6'],
         'v8js' => ['5.6'],
         'vips' => ['5.6'],


### PR DESCRIPTION
Phalcon supports PHP 7.1 and 7.2 as of v3.3.0

Issue: #453 