### PR TITLE
Use kaniko for building

### DIFF
--- a/builder/php-latest.yaml
+++ b/builder/php-latest.yaml
@@ -1,7 +1,5 @@
 steps:
   - name: 'gcr.io/gcp-runtimes/php/gen-dockerfile:latest'
     args: ['--php72-image', 'gcr.io/google-appengine/php72:latest', '--php71-image', 'gcr.io/google-appengine/php71:latest', '--php70-image', 'gcr.io/google-appengine/php70:latest', '--php56-image', 'gcr.io/google-appengine/php56:latest']
-  - name: 'gcr.io/cloud-builders/docker:latest'
-    args: ['build', '-t', '$_OUTPUT_IMAGE', '--network=cloudbuild', '.']
-images:
-  - '$_OUTPUT_IMAGE'
+  - name: 'gcr.io/kaniko-project/executor:v0.4.0'
+    args: ['--destination=$_OUTPUT_IMAGE']


### PR DESCRIPTION
kaniko builds container images from a Dockerfile, and enables future improvements to speed up builds by using the image registry as a layer cache (GoogleContainerTools/kaniko#300)

