### PR TITLE
Allow building phalcon up to php v7.2

### DIFF
--- a/package-builder/extensions/phalcon/build.sh
+++ b/package-builder/extensions/phalcon/build.sh
@@ -8,14 +8,26 @@ echo "Building phalcon for gcp-php${SHORT_VERSION}"
 
 PNAME="gcp-php${SHORT_VERSION}-phalcon"
 
-# Download the source
-download_from_tarball https://github.com/phalcon/cphalcon/archive/v3.0.4.tar.gz 3.0.4
-
 # Build directories are different for php 5 vs 7
 if [ ${SHORT_VERSION} == "56" ]; then
+    # Download the source
+    download_from_tarball https://github.com/phalcon/cphalcon/archive/v3.0.4.tar.gz 3.0.4
     install_last_package gcp-php${SHORT_VERSION}-json
     PACKAGE_DIR=${PACKAGE_DIR}/build/php5/64bits/
 elif [ ${SHORT_VERSION} == "70" ]; then
+    # Download the source
+    download_from_tarball https://github.com/phalcon/cphalcon/archive/v3.2.4.tar.gz 3.2.4
+    # No json as it's inside php from php 7
+    PACKAGE_DIR=${PACKAGE_DIR}/build/php7/64bits/
+elif [ ${SHORT_VERSION} == "71" ]; then
+    # Download the source
+    download_from_tarball https://github.com/phalcon/cphalcon/archive/v3.3.2.tar.gz 3.3.2
+    # No json as it's inside php from php 7
+    PACKAGE_DIR=${PACKAGE_DIR}/build/php7/64bits/
+elif [ ${SHORT_VERSION} == "72" ]; then
+    # Download the source
+    download_from_tarball https://github.com/phalcon/cphalcon/archive/v3.4.2.tar.gz 3.4.2
+    # No json as it's inside php from php 7
     PACKAGE_DIR=${PACKAGE_DIR}/build/php7/64bits/
 else
     echo "skipping Phalcon for gcp-php${SHORT_VERSION} - not yet supported"

--- a/php-base/build-scripts/src/InstallExtensions.php
+++ b/php-base/build-scripts/src/InstallExtensions.php
@@ -88,7 +88,6 @@ class InstallExtensions
         'memcache' => ['7.0', '7.1', '7.2'],
         'mongo' => ['7.0', '7.1', '7.2'],
         'opencensus' => ['5.6'],
-        'phalcon' => ['7.1', '7.2'],
         'stackdriver_debugger' => ['5.6'],
         'v8js' => ['5.6'],
         'vips' => ['5.6'],


### PR DESCRIPTION
This change updates the build scripts to build the appropriate latest
versions of phalcon for each PHP version from PHP v7.0 onwards. Addresses #453 