### PR TITLE
Enable opcache file to improve CLI scripts speed

### DIFF
--- a/package-builder/debian/rules.in
+++ b/package-builder/debian/rules.in
@@ -26,7 +26,7 @@ override_dh_auto_configure:
 	--enable-intl=shared \
 	--enable-mbstring \
 	--enable-mysqlnd \
-	--enable-opcache \
+	--enable-opcache-file \
 	--enable-pcntl \
 	--enable-shared \
 	--enable-shmop=shared \


### PR DESCRIPTION
As all the GAE deployments are atomic, we can compile with the flag `--enable-opcache-file`, and the user choose if he wants or not to enable it on the php.ini file.