### PR TITLE
Adding ubuntu-packages.cfg

### DIFF
--- a/scripts/ubuntu-packages.cfg
+++ b/scripts/ubuntu-packages.cfg
@@ -1,0 +1,10 @@
+env_vars {
+  key: "GOOGLE_PROJECT_ID"
+  value: "php-mvm-a"
+}
+
+env_vars {
+  key: "PHP_VERSIONS"
+  value: "7.2.22-1,7.1.32-1"
+}
+


### PR DESCRIPTION
Without this config file, the update-gcs script will fail to push the…correct package versions, which will cause the release steps to push the wrong versions.