### PR TITLE
Add app.yaml path to the environment variables

### DIFF
--- a/builder/php-latest.yaml
+++ b/builder/php-latest.yaml
@@ -1,5 +1,7 @@
 steps:
   - name: 'gcr.io/gcp-runtimes/php/gen-dockerfile:latest'
     args: ['--php72-image', 'gcr.io/google-appengine/php72:latest', '--php71-image', 'gcr.io/google-appengine/php71:latest']
+    env: 'GAE_APPLICATION_YAML_PATH=$_GAE_APPLICATION_YAML_PATH'
   - name: 'gcr.io/kaniko-project/executor:v0.6.0'
     args: ['--destination=$_OUTPUT_IMAGE']
+    env: 'GAE_APPLICATION_YAML_PATH=$_GAE_APPLICATION_YAML_PATH'


### PR DESCRIPTION
The PHP runtime builder depends on this environment variable present. It is added by gcloud during the `gcloud app deploy` execution, but it's better to have it explicitly add it here.