### PR TITLE
Update tz database

### DIFF
--- a/package-builder/extensions/timezonedb/build.sh
+++ b/package-builder/extensions/timezonedb/build.sh
@@ -7,6 +7,6 @@ echo "Building timezonedb for gcp-php${SHORT_VERSION}"
 PNAME="gcp-php${SHORT_VERSION}-timezonedb"
 
 # Download the source
-download_from_pecl timezonedb 2017.2
+download_from_pecl timezonedb 2019.3
 
 build_package timezonedb


### PR DESCRIPTION
Addressing issue with php showing wrong TZ:
root@16464840edfa:/app# date
Mon Jan 27 17:57:20 UTC 2020
root@16464840edfa:/app# timedatectl set-timezone America/Sao_Paulo
root@16464840edfa:/app# date
Mon Jan 27 17:57:36 UTC 2020
root@16464840edfa:/app# timedatactl
bash: timedatactl: command not found
root@16464840edfa:/app# timedatectl
      Local time: Mon 2020-01-27 14:57:47 -03
  Universal time: Mon 2020-01-27 17:57:47 UTC
        RTC time: Mon 2020-01-27 17:57:47
       Time zone: America/Sao_Paulo (-03, -0300)
 Network time on: no
NTP synchronized: yes
 RTC in local TZ: no
root@16464840edfa:/app# php -a
Interactive shell

php > date_default_timezone_set('America/Sao_Paulo');
php > echo date("h:i:sa");
03:58:30pm
