### PR TITLE
Pinning protobuf version to 3.10.0

### DIFF
--- a/package-builder/extensions/protobuf/build.sh
+++ b/package-builder/extensions/protobuf/build.sh
@@ -9,5 +9,5 @@ echo "Building protobuf for gcp-php${SHORT_VERSION}"
 PNAME="gcp-php${SHORT_VERSION}-protobuf"
 
 # Download the source
-download_from_pecl protobuf
+download_from_pecl protobuf 3.10.0
 build_package protobuf


### PR DESCRIPTION
We're pinning protobuf to version 3.10.0 in an attempt to give customers who are experiencing segfaults due to protobuf 3.11.2 issues a break until a protobuf fix can be released.