### PR TITLE
Restoring the ability to specify php56 and php70 images

### DIFF
--- a/builder/gen-dockerfile/src/Builder/GenFilesCommand.php
+++ b/builder/gen-dockerfile/src/Builder/GenFilesCommand.php
@@ -76,6 +76,18 @@ class GenFilesCommand extends Command
                 'The PHP 71 base image of the Dockerfile'
             )
             ->addOption(
+                'php70-image',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The PHP 70 base image of the Dockerfile'
+            )
+            ->addOption(
+                'php56-image',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The PHP 56 base image of the Dockerfile'
+            )
+            ->addOption(
                 'workspace',
                 'w',
                 InputOption::VALUE_REQUIRED,

--- a/builder/gen-dockerfile/src/DetectPhpVersion.php
+++ b/builder/gen-dockerfile/src/DetectPhpVersion.php
@@ -101,6 +101,8 @@ class DetectPhpVersion
             trim(file_get_contents('/opt/php73_version')),
             trim(file_get_contents('/opt/php72_version')),
             trim(file_get_contents('/opt/php71_version')),
+            trim(file_get_contents('/opt/php70_version')),
+            trim(file_get_contents('/opt/php56_version')),
         ];
     }
 }

--- a/builder/gen-dockerfile/tests/GenFilesCommandTest.php
+++ b/builder/gen-dockerfile/tests/GenFilesCommandTest.php
@@ -76,6 +76,8 @@ class GenFilesCommandTest extends TestCase
         if ($baseImages === null) {
             $baseImages =
                 [
+                    '--php56-image' => 'gcr.io/google-appengine/php56:latest',
+                    '--php70-image' => 'gcr.io/google-appengine/php70:latest',
                     '--php71-image' => 'gcr.io/google-appengine/php71:latest',
                     '--php72-image' => 'gcr.io/google-appengine/php72:latest',
                     '--php73-image' => 'gcr.io/google-appengine/php73:latest',
@@ -187,6 +189,32 @@ class GenFilesCommandTest extends TestCase
                 '\\Google\\Cloud\\Runtimes\\Builder\\Exception\\InvalidComposerFlagsException'
             ],
             [
+                // PHP 5.6
+                __DIR__ . '/test_data/php56',
+                null,
+                '',
+                '/app',
+                'added by the php runtime builder',
+                'gcr.io/google-appengine/php56:latest',
+                ["COMPOSER_FLAGS='--no-dev --prefer-dist' \\\n",
+                 "FRONT_CONTROLLER_FILE='index.php' \\\n",
+                 "DETECTED_PHP_VERSION='5.6' \n"
+                ]
+            ],
+            [
+                // PHP 7.0
+                __DIR__ . '/test_data/php70',
+                null,
+                '',
+                '/app',
+                'added by the php runtime builder',
+                'gcr.io/google-appengine/php70:latest',
+                ["COMPOSER_FLAGS='--no-dev --prefer-dist' \\\n",
+                 "FRONT_CONTROLLER_FILE='index.php' \\\n",
+                 "DETECTED_PHP_VERSION='7.0' \n"
+                ]
+            ],
+            [
                 // PHP 7.1
                 __DIR__ . '/test_data/php71',
                 null,
@@ -287,6 +315,8 @@ class GenFilesCommandTest extends TestCase
                 // Overrides baseImage
                 __DIR__ . '/test_data/simplest',
                 [
+                    '--php56-image' => 'gcr.io/php-mvm-a-28051/php56:latest',
+                    '--php70-image' => 'gcr.io/php-mvm-a-28051/php70:latest',
                     '--php71-image' => 'gcr.io/php-mvm-a-28051/php71:latest',
                     '--php72-image' => 'gcr.io/php-mvm-a-28051/php72:latest',
                     '--php73-image' => 'gcr.io/php-mvm-a-28051/php73:latest',

--- a/builder/php-latest.yaml
+++ b/builder/php-latest.yaml
@@ -1,6 +1,6 @@
 steps:
   - name: 'gcr.io/gcp-runtimes/php/gen-dockerfile:latest'
-    args: ['--php73-image', 'gcr.io/google-appengine/php73:latest', '--php72-image', 'gcr.io/google-appengine/php72:latest', '--php71-image', 'gcr.io/google-appengine/php71:latest']
+    args: ['--php73-image', 'gcr.io/google-appengine/php73:latest', '--php72-image', 'gcr.io/google-appengine/php72:latest', '--php71-image', 'gcr.io/google-appengine/php71:latest', '--php70-image', 'gcr.io/google-appengine/php70:latest', '--php56-image', 'gcr.io/google-appengine/php56:latest']
     env: 'GAE_APPLICATION_YAML_PATH=$_GAE_APPLICATION_YAML_PATH'
   - name: 'gcr.io/kaniko-project/executor:v0.6.0'
     args: ['--destination=$_OUTPUT_IMAGE']


### PR DESCRIPTION
Back in May 2019 I deleted all the infrastructure for producing and using 5.6 and 7.0 images since they were EOL'd.  And this had the knock on effect of making it impossible to use those old images.  This change is intended to allow customers to specify the old images if they want, even though they can not be updated any longer.