### PR TITLE
Set parallel in debian rules.

### DIFF
--- a/package-builder/debian/rules.in
+++ b/package-builder/debian/rules.in
@@ -6,7 +6,7 @@ export DH_VERBOSE=1
 export VERBOSE=1
 
 %:
-	dh $@
+	dh $@ --parallel
 
 override_dh_auto_configure:
 	rm -f configure \

--- a/package-builder/libraries/libv8/debian/rules
+++ b/package-builder/libraries/libv8/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@
+	dh $@ --parallel
 
 override_dh_auto_configure:
 	CXX=g++-8 tools/dev/v8gen.py -vv x64.release -- is_component_build=true


### PR DESCRIPTION
Add --parallel flag to the debian rules. It seems to be accelerating the build (from ~41 mins to ~27 mins). 